### PR TITLE
RALPH: #80 Cockpit shell + Live tab MVP (child supervision + event log)

### DIFF
--- a/.sandcastle/cockpit-core.mts
+++ b/.sandcastle/cockpit-core.mts
@@ -1,0 +1,321 @@
+/**
+ * Cockpit core — the pure, unit-testable helpers behind the Cockpit TUI
+ * (`cockpit.tsx`, issue #80; ADR-0008). The Ink React layer is intentionally
+ * thin and untested (per CODING_STANDARDS.md); everything with logic lives here
+ * so it can be pinned by tests:
+ *
+ * - the **tab model** (`COCKPIT_TABS` + `cycleTab`) behind the tab-switch keybind,
+ * - the **NDJSON stream** decode (`splitNdjsonChunk` + `parseEventLine`) that turns
+ *   the supervised child's stdout chunks into typed orchestrator events,
+ * - the **event log** (`formatEventLog` + `appendLogLine`) that renders those
+ *   events as bounded, scrolling one-liners, and
+ * - the **child-exit** classification (`describeChildExit`) that decides whether a
+ *   child that went away was a clean Stop or a crash to surface.
+ *
+ * - the **supervisor** (`spawnOrchestrator`) that launches the orchestrator as a
+ *   child process and threads its stdout/stderr through the decode above.
+ *
+ * The event *shape* is owned by `events.mts` (the contract the orchestrator emits
+ * and the Cockpit consumes); this module only decodes and presents it.
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import type { OrchestratorEvent } from "./events.mts";
+
+/** The Cockpit's tabbed modes, in cycle order (CONTEXT.md: Cockpit). */
+export const COCKPIT_TABS = ["live", "sessions", "maintenance"] as const;
+
+/** One Cockpit tab id. */
+export type CockpitTab = (typeof COCKPIT_TABS)[number];
+
+/** Direction the tab-switch keybind moves through {@link COCKPIT_TABS}. */
+export type CycleDirection = "next" | "prev";
+
+/**
+ * The pure model behind the ←/→ tab-switch keybind: return the tab one step
+ * from `current` in `direction`, wrapping at both ends so the three tabs form a
+ * ring. Kept side-effect-free so the wrap-around is unit-testable in isolation.
+ */
+export function cycleTab(current: CockpitTab, direction: CycleDirection): CockpitTab {
+  const i = COCKPIT_TABS.indexOf(current);
+  const delta = direction === "next" ? 1 : -1;
+  const n = COCKPIT_TABS.length;
+  return COCKPIT_TABS[(i + delta + n) % n];
+}
+
+/** Every `type` discriminator the orchestrator can emit — the allow-list
+ *  `parseEventLine` checks so a stray non-event JSON line (or a future unknown
+ *  type) is dropped rather than mis-rendered. */
+const KNOWN_EVENT_TYPES = new Set<OrchestratorEvent["type"]>([
+  "tick",
+  "pool-full",
+  "buckets",
+  "dispatch",
+  "planner-emitted",
+  "planner-skipped",
+  "planner-no-plan",
+  "planner-failed",
+  "noop-escalated",
+  "gh-error",
+  "session-resolved",
+]);
+
+/**
+ * Decode one line of the child's NDJSON stdout into a typed
+ * {@link OrchestratorEvent}, or `null` when the line is not a usable event.
+ *
+ * The child's stdout is NDJSON-only in `SANDCASTLE_EVENT_FORMAT=ndjson` mode,
+ * but a supervised process can still emit stray output (a blank line, a runtime
+ * stack trace, a stray library log). So this is deliberately defensive: it
+ * returns `null` for a blank line, non-JSON, non-object JSON, or a JSON object
+ * whose `type` is not a known orchestrator event — the Cockpit simply skips
+ * those rather than crashing or showing garbage.
+ */
+export function parseEventLine(line: string): OrchestratorEvent | null {
+  const trimmed = line.trim();
+  if (trimmed === "") return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const type = (parsed as { type?: unknown }).type;
+  if (typeof type !== "string" || !KNOWN_EVENT_TYPES.has(type as OrchestratorEvent["type"])) {
+    return null;
+  }
+  return parsed as OrchestratorEvent;
+}
+
+/** The result of feeding one stdout chunk through {@link splitNdjsonChunk}: the
+ *  complete lines it yielded plus the still-incomplete trailing `rest` to carry
+ *  into the next call. */
+export interface ChunkSplit {
+  /** The complete lines decoded from `buffer + chunk` (newline-terminated). */
+  readonly lines: string[];
+  /** The trailing partial line (no newline yet); prepend to the next chunk. */
+  readonly rest: string;
+}
+
+/**
+ * Split a freshly-arrived stdout `chunk` into complete lines, carrying any
+ * partial trailing line in `rest`. A child's stdout arrives in arbitrary
+ * chunks that do NOT respect line boundaries — one write can split a JSON
+ * object across two `data` events — so the supervisor threads `rest` back in as
+ * the `buffer` on the next call. Everything up to the final newline is a
+ * complete line; whatever follows the last newline is the incomplete remainder
+ * (empty when the chunk ended exactly on a newline).
+ *
+ * Pure (buffer in, {lines, rest} out) so the cross-chunk reassembly is
+ * unit-testable without a live child process.
+ */
+export function splitNdjsonChunk(buffer: string, chunk: string): ChunkSplit {
+  const combined = buffer + chunk;
+  const parts = combined.split("\n");
+  const rest = parts.pop() ?? "";
+  return { lines: parts, rest };
+}
+
+/**
+ * Render one orchestrator event as a single compact line for the Live tab's
+ * scrolling event log. Distinct from `formatEventProse` in `events.mts`: this is
+ * a **total** formatter — every event produces exactly one glanceable line,
+ * including a *successful* `session-resolved` (which prose deliberately renders
+ * to nothing because the headless `lifecycle` markers cover it). The Cockpit's
+ * job is the opposite of headless: surface every live resolution.
+ *
+ * No timestamp is included — the log line is the event's semantics only; the
+ * React layer prefixes a wall-clock time from `event.ts`. Pure so the exact
+ * strings are unit-testable in isolation.
+ */
+export function formatEventLog(event: OrchestratorEvent): string {
+  switch (event.type) {
+    case "tick":
+      return `tick · ${event.free}/${event.poolSize} free · ${event.inflight} in-flight`;
+    case "dispatch":
+      return event.role === "implementer"
+        ? `▶ dispatch impl #${event.issue}: ${event.title}`
+        : `▶ dispatch ${roleAbbr(event.role)} PR #${event.pr} (#${event.issue})`;
+    case "session-resolved":
+      return event.status === "ok"
+        ? `✓ ${roleAbbr(event.role)} #${event.issue} resolved · ${event.commits} commits`
+        : `✗ ${roleAbbr(event.role)} #${event.issue} failed · ${event.error}`;
+    case "pool-full":
+      return "pool full · gh query skipped";
+    case "buckets":
+      return `buckets · merge ${event.merge} · review ${event.review} · agent ${event.agent} (${event.actionable} actionable)`;
+    case "planner-emitted":
+      return `planner emitted ${event.count} issue(s)`;
+    case "planner-skipped":
+      return "planner skipped";
+    case "planner-no-plan":
+      return "planner produced no plan";
+    case "planner-failed":
+      return `⚠ planner failed · ${event.error}`;
+    case "noop-escalated":
+      return `⚠ #${event.issue} no commits · escalated to ready-for-human`;
+    case "gh-error":
+      return `⚠ gh ${event.args.join(" ")} failed · ${event.error}`;
+    default: {
+      // Exhaustiveness guard: adding a new OrchestratorEvent type without a log
+      // line here is a compile error, so the Live log can never silently omit one.
+      const unreachable: never = event;
+      return unreachable;
+    }
+  }
+}
+
+/**
+ * Append `entry` to the scrolling event log, keeping at most the last `cap`
+ * entries. The Live feed is a long-lived stream (a tick every ~60s plus every
+ * dispatch/resolution), so the log is a bounded ring: once it exceeds `cap` the
+ * oldest entries fall off. Returns a NEW array (never mutates `lines`) so it
+ * drops straight into a React `setState` updater. Generic over the entry type so
+ * the Cockpit can carry richer entries (line + colour) through the same ring.
+ */
+export function appendLogLine<T>(lines: readonly T[], entry: T, cap: number): T[] {
+  const next = [...lines, entry];
+  return next.length > cap ? next.slice(next.length - cap) : next;
+}
+
+/** How a supervised orchestrator child ended, once it is gone. `stopped` is a
+ *  clean end (a user Stop, or a rare clean exit); `crashed` is surfaced in the
+ *  UI as an error without taking the Cockpit down (ADR-0008). */
+export interface ChildExit {
+  readonly status: "stopped" | "crashed";
+  /** A short human line for the status bar / event log. */
+  readonly message: string;
+}
+
+/** The raw exit signal from `child.on("exit", (code, signal))` plus whether the
+ *  Cockpit itself asked the child to stop (so a Stop-triggered SIGTERM is not
+ *  mistaken for a crash). */
+export interface ChildExitInput {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | string | null;
+  /** True when this exit followed a user Stop (or quit) — the Cockpit killed it. */
+  readonly stoppedByUser: boolean;
+}
+
+/**
+ * Classify a departed orchestrator child as a clean Stop or a crash to surface.
+ * The orchestrator loop never self-exits, so any exit the Cockpit did NOT ask
+ * for is unexpected: a non-zero code or an unexpected signal is a crash (shown
+ * in the UI without killing the Cockpit, per ADR-0008), while a user-requested
+ * Stop — or the degenerate clean `exit(0)` — is just "stopped". Pure so the
+ * classification is unit-testable without spawning a process.
+ */
+export function describeChildExit(input: ChildExitInput): ChildExit {
+  if (input.stoppedByUser) {
+    return { status: "stopped", message: "orchestrator stopped" };
+  }
+  if (input.code !== null && input.code !== 0) {
+    return { status: "crashed", message: `orchestrator crashed (exit code ${input.code})` };
+  }
+  if (input.signal !== null) {
+    return { status: "crashed", message: `orchestrator crashed (signal ${input.signal})` };
+  }
+  return { status: "stopped", message: "orchestrator exited" };
+}
+
+/** How to launch the orchestrator child. Injected (rather than hard-coded) so
+ *  the supervisor's wiring can be integration-tested against a fake emitter,
+ *  mirroring this codebase's env/dep injection style (`createEvents`, `logPath`). */
+export interface SpawnConfig {
+  readonly command: string;
+  readonly args: string[];
+  readonly cwd?: string;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+/** The sinks the {@link spawnOrchestrator} supervisor pushes decoded child output
+ *  into — the Cockpit maps these onto its event log + status state. */
+export interface OrchestratorHandlers {
+  /** A decoded orchestrator event from the child's NDJSON stdout. */
+  onEvent(event: OrchestratorEvent): void;
+  /** A stdout line that was NOT a parseable event (rare; surfaced raw). */
+  onStdoutRaw(line: string): void;
+  /** A stderr line — the per-agent sub-feed or a crash trace. */
+  onStderr(line: string): void;
+  /** The child is gone: classified as a clean stop or a crash to surface. */
+  onExit(status: ChildExit["status"], message: string): void;
+  /** The child could not be spawned at all (e.g. the command was not found). */
+  onSpawnError(message: string): void;
+}
+
+/** Handle to a running orchestrator child — the Stop control the UI needs. */
+export interface Supervisor {
+  /** Flag this exit as user-requested and SIGTERM the child. */
+  stop(): void;
+}
+
+/**
+ * Spawn the orchestrator as a supervised child and wire its output into
+ * `handlers`. This is the heart of ADR-0008: the orchestrator runs as a child
+ * process, never in-process, so a throw in its loop cannot take the Cockpit
+ * down. In NDJSON mode (set by the caller via `config.env`) the child's stdout
+ * is pure NDJSON — each complete line is reassembled across chunks by
+ * {@link splitNdjsonChunk}, decoded by {@link parseEventLine}, and delivered as a
+ * typed event (or raw, if it somehow isn't one). stderr (the per-agent sub-feed
+ * / crash traces) is delivered line-by-line. Exit is classified by
+ * {@link describeChildExit}: a user {@link Supervisor.stop} is a clean `stopped`,
+ * anything else unexpected is `crashed`.
+ */
+export function spawnOrchestrator(config: SpawnConfig, handlers: OrchestratorHandlers): Supervisor {
+  let stoppedByUser = false;
+  let outBuffer = "";
+  let errBuffer = "";
+
+  const child: ChildProcess = spawn(config.command, config.args, {
+    cwd: config.cwd,
+    env: config.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  child.stdout?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    const split = splitNdjsonChunk(outBuffer, chunk);
+    outBuffer = split.rest;
+    for (const line of split.lines) {
+      if (line.trim() === "") continue;
+      const event = parseEventLine(line);
+      if (event) handlers.onEvent(event);
+      else handlers.onStdoutRaw(line);
+    }
+  });
+
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    const split = splitNdjsonChunk(errBuffer, chunk);
+    errBuffer = split.rest;
+    for (const line of split.lines) {
+      if (line.trim() !== "") handlers.onStderr(line);
+    }
+  });
+
+  child.on("error", (err) => handlers.onSpawnError(err.message));
+  child.on("exit", (code, signal) => {
+    const exit = describeChildExit({ code, signal, stoppedByUser });
+    handlers.onExit(exit.status, exit.message);
+  });
+
+  return {
+    stop() {
+      stoppedByUser = true;
+      child.kill("SIGTERM");
+    },
+  };
+}
+
+/** The compact role tag used in log lines: `impl` / `rev` / `merger`. Mirrors
+ *  the labels the orchestrator's `lifecycle`/prose output already uses. */
+function roleAbbr(role: "implementer" | "reviewer" | "merger"): string {
+  switch (role) {
+    case "implementer":
+      return "impl";
+    case "reviewer":
+      return "rev";
+    case "merger":
+      return "merger";
+  }
+}

--- a/.sandcastle/cockpit-core.test.mts
+++ b/.sandcastle/cockpit-core.test.mts
@@ -1,0 +1,340 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  appendLogLine,
+  COCKPIT_TABS,
+  cycleTab,
+  describeChildExit,
+  formatEventLog,
+  parseEventLine,
+  spawnOrchestrator,
+  splitNdjsonChunk,
+  type OrchestratorHandlers,
+} from "./cockpit-core.mts";
+import type { OrchestratorEvent } from "./events.mts";
+
+/** Build one event of a given type with a fixed timestamp for the log formatter. */
+function evt(event: Omit<OrchestratorEvent, "ts">): OrchestratorEvent {
+  return { ...(event as object), ts: "2026-07-04T10:00:00.000Z" } as OrchestratorEvent;
+}
+
+// ── cycleTab: the tab-switch keybind's pure model ───────────────────────────
+
+describe("cycleTab", () => {
+  it("advances to the next tab and wraps past the last", () => {
+    expect(cycleTab("live", "next")).toBe("sessions");
+    expect(cycleTab("sessions", "next")).toBe("maintenance");
+    expect(cycleTab("maintenance", "next")).toBe("live");
+  });
+
+  it("steps to the previous tab and wraps before the first", () => {
+    expect(cycleTab("maintenance", "prev")).toBe("sessions");
+    expect(cycleTab("sessions", "prev")).toBe("live");
+    expect(cycleTab("live", "prev")).toBe("maintenance");
+  });
+
+  it("lists the three tabs in Live → Sessions → Maintenance order", () => {
+    expect(COCKPIT_TABS).toEqual(["live", "sessions", "maintenance"]);
+  });
+});
+
+// ── parseEventLine: decode one NDJSON stdout line → typed event | null ───────
+
+describe("parseEventLine", () => {
+  it("parses a valid NDJSON event line into the typed event", () => {
+    const line = JSON.stringify({
+      type: "tick",
+      free: 3,
+      poolSize: 10,
+      inflight: 7,
+      ts: "2026-07-04T10:00:00.000Z",
+    });
+    expect(parseEventLine(line)).toEqual({
+      type: "tick",
+      free: 3,
+      poolSize: 10,
+      inflight: 7,
+      ts: "2026-07-04T10:00:00.000Z",
+    });
+  });
+
+  it("returns null for a blank line", () => {
+    expect(parseEventLine("")).toBeNull();
+    expect(parseEventLine("   ")).toBeNull();
+  });
+
+  it("returns null for non-JSON stray output (a stack trace, a stray log)", () => {
+    expect(parseEventLine("Error: boom at foo.mts:1")).toBeNull();
+    expect(parseEventLine("{ not json")).toBeNull();
+  });
+
+  it("returns null for JSON whose type is not a known orchestrator event", () => {
+    expect(parseEventLine(JSON.stringify({ type: "mystery", ts: "x" }))).toBeNull();
+    expect(parseEventLine(JSON.stringify({ hello: "world" }))).toBeNull();
+    expect(parseEventLine(JSON.stringify([1, 2, 3]))).toBeNull();
+  });
+});
+
+// ── splitNdjsonChunk: buffer partial trailing lines across stdout chunks ─────
+
+describe("splitNdjsonChunk", () => {
+  it("splits complete newline-terminated lines with an empty remainder", () => {
+    expect(splitNdjsonChunk("", "a\nb\nc\n")).toEqual({
+      lines: ["a", "b", "c"],
+      rest: "",
+    });
+  });
+
+  it("buffers a chunk without a trailing newline as the remainder", () => {
+    expect(splitNdjsonChunk("", "a\nb\nhalf")).toEqual({
+      lines: ["a", "b"],
+      rest: "half",
+    });
+  });
+
+  it("completes a buffered partial line with the next chunk", () => {
+    const first = splitNdjsonChunk("", '{"type":"tic');
+    expect(first).toEqual({ lines: [], rest: '{"type":"tic' });
+    const second = splitNdjsonChunk(first.rest, 'k"}\n');
+    expect(second).toEqual({ lines: ['{"type":"tick"}'], rest: "" });
+  });
+});
+
+// ── formatEventLog: one event → one compact scrolling-log line ───────────────
+
+describe("formatEventLog", () => {
+  it("renders a Poll tick as a compact capacity line", () => {
+    expect(formatEventLog(evt({ type: "tick", free: 3, poolSize: 10, inflight: 7 }))).toBe(
+      "tick · 3/10 free · 7 in-flight"
+    );
+  });
+
+  it("renders a SUCCESSFUL session resolution (which prose suppresses)", () => {
+    expect(
+      formatEventLog(
+        evt({
+          type: "session-resolved",
+          role: "implementer",
+          issue: 12,
+          branch: "sandcastle/issue-12",
+          status: "ok",
+          commits: 2,
+          error: null,
+        })
+      )
+    ).toBe("✓ impl #12 resolved · 2 commits");
+  });
+
+  it("renders a FAILED session resolution with its error", () => {
+    expect(
+      formatEventLog(
+        evt({
+          type: "session-resolved",
+          role: "reviewer",
+          issue: 44,
+          branch: "sandcastle/issue-44",
+          status: "failed",
+          commits: 0,
+          error: "boom",
+        })
+      )
+    ).toBe("✗ rev #44 failed · boom");
+  });
+
+  it("renders an Implementer dispatch with the issue title and branch", () => {
+    expect(
+      formatEventLog(
+        evt({
+          type: "dispatch",
+          role: "implementer",
+          issue: 12,
+          branch: "sandcastle/issue-12",
+          pr: null,
+          title: "Add the widget",
+        })
+      )
+    ).toBe("▶ dispatch impl #12: Add the widget");
+  });
+
+  it("renders a Reviewer/Merger dispatch with the PR and issue", () => {
+    expect(
+      formatEventLog(
+        evt({
+          type: "dispatch",
+          role: "merger",
+          issue: 44,
+          branch: "sandcastle/issue-44",
+          pr: 90,
+          title: null,
+        })
+      )
+    ).toBe("▶ dispatch merger PR #90 (#44)");
+  });
+
+  it("renders the remaining informational and warning events", () => {
+    expect(formatEventLog(evt({ type: "pool-full" }))).toBe("pool full · gh query skipped");
+    expect(
+      formatEventLog(evt({ type: "buckets", merge: 1, review: 2, agent: 5, actionable: 3 }))
+    ).toBe("buckets · merge 1 · review 2 · agent 5 (3 actionable)");
+    expect(formatEventLog(evt({ type: "planner-emitted", count: 3 }))).toBe(
+      "planner emitted 3 issue(s)"
+    );
+    expect(formatEventLog(evt({ type: "planner-skipped" }))).toBe("planner skipped");
+    expect(formatEventLog(evt({ type: "planner-no-plan" }))).toBe("planner produced no plan");
+    expect(formatEventLog(evt({ type: "planner-failed", error: "opus down" }))).toBe(
+      "⚠ planner failed · opus down"
+    );
+    expect(formatEventLog(evt({ type: "noop-escalated", issue: 12 }))).toBe(
+      "⚠ #12 no commits · escalated to ready-for-human"
+    );
+    expect(
+      formatEventLog(evt({ type: "gh-error", args: ["issue", "list"], error: "rate limited" }))
+    ).toBe("⚠ gh issue list failed · rate limited");
+  });
+});
+
+// ── appendLogLine: bounded ring buffer for the scrolling log ─────────────────
+
+describe("appendLogLine", () => {
+  it("appends a line while under the cap", () => {
+    expect(appendLogLine(["a", "b"], "c", 5)).toEqual(["a", "b", "c"]);
+  });
+
+  it("drops the oldest lines once the cap is exceeded, keeping the last N", () => {
+    expect(appendLogLine(["a", "b", "c"], "d", 3)).toEqual(["b", "c", "d"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = ["a", "b"];
+    appendLogLine(input, "c", 5);
+    expect(input).toEqual(["a", "b"]);
+  });
+});
+
+// ── describeChildExit: clean Stop vs crash to surface ────────────────────────
+
+describe("describeChildExit", () => {
+  it("classifies a user-initiated Stop (SIGTERM) as stopped, not a crash", () => {
+    expect(describeChildExit({ code: null, signal: "SIGTERM", stoppedByUser: true })).toEqual({
+      status: "stopped",
+      message: "orchestrator stopped",
+    });
+  });
+
+  it("classifies a non-zero exit that the user did not request as a crash", () => {
+    expect(describeChildExit({ code: 1, signal: null, stoppedByUser: false })).toEqual({
+      status: "crashed",
+      message: "orchestrator crashed (exit code 1)",
+    });
+  });
+
+  it("classifies a kill by an unexpected signal as a crash", () => {
+    expect(describeChildExit({ code: null, signal: "SIGSEGV", stoppedByUser: false })).toEqual({
+      status: "crashed",
+      message: "orchestrator crashed (signal SIGSEGV)",
+    });
+  });
+
+  it("classifies a clean exit(0) the user did not request as stopped", () => {
+    expect(describeChildExit({ code: 0, signal: null, stoppedByUser: false })).toEqual({
+      status: "stopped",
+      message: "orchestrator exited",
+    });
+  });
+});
+
+// ── spawnOrchestrator: the supervised-child pipeline, end-to-end ─────────────
+//
+// Spawns a REAL child (a `node -e` fake orchestrator) so the whole seam is
+// exercised: process spawn, chunked stdout → NDJSON decode → typed events,
+// stderr line delivery, and exit classification. No Docker/gh/agents involved.
+
+/** Collect everything a supervised child produces, resolving once it exits. */
+function runFakeOrchestrator(
+  script: string,
+  drive?: (sup: { stop(): void }) => void
+): Promise<{
+  events: OrchestratorEvent[];
+  stdoutRaw: string[];
+  stderr: string[];
+  exit: { status: string; message: string } | null;
+  spawnError: string | null;
+}> {
+  return new Promise((resolve) => {
+    const events: OrchestratorEvent[] = [];
+    const stdoutRaw: string[] = [];
+    const stderr: string[] = [];
+    let exit: { status: string; message: string } | null = null;
+    let spawnError: string | null = null;
+    const handlers: OrchestratorHandlers = {
+      onEvent: (e) => events.push(e),
+      onStdoutRaw: (l) => stdoutRaw.push(l),
+      onStderr: (l) => stderr.push(l),
+      onExit: (status, message) => {
+        exit = { status, message };
+        resolve({ events, stdoutRaw, stderr, exit, spawnError });
+      },
+      onSpawnError: (message) => {
+        spawnError = message;
+        resolve({ events, stdoutRaw, stderr, exit, spawnError });
+      },
+    };
+    const sup = spawnOrchestrator({ command: process.execPath, args: ["-e", script] }, handlers);
+    if (drive) drive(sup);
+  });
+}
+
+describe("spawnOrchestrator", () => {
+  it("decodes a child's NDJSON stdout into typed events and classifies clean exit", async () => {
+    // The fake writes two events across an AWKWARD chunk boundary (a split mid-
+    // JSON) to prove the cross-chunk line reassembly holds through a real pipe.
+    const script = `
+      const tick = JSON.stringify({type:"tick",free:1,poolSize:10,inflight:0,ts:"2026-07-04T10:00:00.000Z"});
+      const done = JSON.stringify({type:"session-resolved",role:"implementer",issue:7,branch:"sandcastle/issue-7",status:"ok",commits:2,error:null,ts:"2026-07-04T10:00:01.000Z"});
+      const all = tick + "\\n" + done + "\\n";
+      process.stdout.write(all.slice(0, 20));
+      setTimeout(() => process.stdout.write(all.slice(20)), 15);
+    `;
+    const result = await runFakeOrchestrator(script);
+    expect(result.events.map((e) => e.type)).toEqual(["tick", "session-resolved"]);
+    expect(result.events[1]).toMatchObject({ type: "session-resolved", issue: 7, commits: 2 });
+    expect(result.spawnError).toBeNull();
+    expect(result.exit).toEqual({ status: "stopped", message: "orchestrator exited" });
+  });
+
+  it("delivers stderr lines (the agent sub-feed) separately from events", async () => {
+    const script = `
+      process.stderr.write("impl #7 · toolCall bash\\n");
+      process.stdout.write(JSON.stringify({type:"pool-full",ts:"2026-07-04T10:00:00.000Z"}) + "\\n");
+    `;
+    const result = await runFakeOrchestrator(script);
+    expect(result.stderr).toContain("impl #7 · toolCall bash");
+    expect(result.events.map((e) => e.type)).toEqual(["pool-full"]);
+  });
+
+  it("surfaces a Stop as a clean stopped exit, not a crash", async () => {
+    // A child that would run forever; the supervisor Stops it after it is alive.
+    const script = `setInterval(() => {}, 1000); process.stdout.write("ready\\n");`;
+    const result = await runFakeOrchestrator(script, (sup) => {
+      setTimeout(() => sup.stop(), 50);
+    });
+    expect(result.exit).toEqual({ status: "stopped", message: "orchestrator stopped" });
+  });
+
+  it("reports a spawn failure (command not found) without throwing", async () => {
+    const events: OrchestratorEvent[] = [];
+    const spawnError = await new Promise<string | null>((resolve) => {
+      spawnOrchestrator(
+        { command: "definitely-not-a-real-binary-xyz", args: [] },
+        {
+          onEvent: (e) => events.push(e),
+          onStdoutRaw: () => {},
+          onStderr: () => {},
+          onExit: () => resolve(null),
+          onSpawnError: (message) => resolve(message),
+        }
+      );
+    });
+    expect(spawnError).toMatch(/ENOENT|not.*found|spawn/i);
+  });
+});

--- a/.sandcastle/cockpit.tsx
+++ b/.sandcastle/cockpit.tsx
@@ -1,0 +1,336 @@
+/**
+ * Sandcastle Cockpit — the single Ink TUI that consolidates the Sandcastle
+ * surfaces into tabbed modes (issue #80; CONTEXT.md: Cockpit, ADR-0008).
+ *
+ * This slice is the foundational tracer bullet: a tabbed shell — **[Live]**
+ * **[Sessions]** **[Maintenance]** — that launches **idle** (no run started).
+ * ←/→ cycle the tabs; `q` / Ctrl-C quit cleanly, stopping any child first.
+ *
+ * The **Live** tab is functional: it **supervises the orchestrator as a child
+ * process** (never in-process — a crash in the loop must not take the Cockpit
+ * down, ADR-0008). Enter **Start**s `tsx main.mts` with
+ * `SANDCASTLE_EVENT_FORMAT=ndjson`; the child's stdout is the structured
+ * **Live feed** (NDJSON, from #78), parsed line-by-line and rendered as a
+ * scrolling **event log**. Enter again **Stop**s it (SIGTERM); Start after a
+ * stop/crash restarts. The child's stderr (the per-agent sub-feed + any crash
+ * trace) is surfaced dimmed in the same log. A child crash/exit is reported in
+ * the UI (status line + a coloured log line) without unmounting the Cockpit.
+ *
+ * **Sessions** and **Maintenance** are placeholder tabs in this slice (their
+ * standalone commands, `sandcastle:browse` / `sandcastle:prune`, still work).
+ * Headless `pnpm sandcastle` (no Cockpit) still runs the orchestrator loop
+ * directly — this file only adds a supervisor on top of that same entry point.
+ *
+ * All logic with behaviour lives in the pure, unit-tested `cockpit-core.mts`
+ * (tab cycling, NDJSON decode, log formatting, child-exit classification); this
+ * file is the thin Ink layer + the imperative spawn wiring, untested per
+ * CODING_STANDARDS.md (like `session-browser.tsx`). It is imported as
+ * `./cockpit-core.mjs` so tsc (which typechecks `.tsx`) resolves the `.mts`
+ * source — the same `.mjs`-specifier convention `session-browser.tsx` uses.
+ *
+ * Run via `pnpm sandcastle:cockpit` (i.e. `tsx .sandcastle/cockpit.tsx`). The
+ * `.sandcastle/package.json` `{"type":"module"}` marker makes this `.tsx` ESM so
+ * Ink's transitive `yoga-layout@3` (top-level await) loads under tsx (ADR-0007).
+ */
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Box, render, Text, useApp, useInput, useStdin, useStdout } from "ink";
+
+import {
+  appendLogLine,
+  COCKPIT_TABS,
+  cycleTab,
+  formatEventLog,
+  spawnOrchestrator,
+  type CockpitTab,
+  type Supervisor,
+} from "./cockpit-core.mjs";
+import type { OrchestratorEvent } from "./events.mjs";
+
+/** Absolute path to the orchestrator entry, resolved from THIS file so the
+ *  child launches regardless of the caller's cwd. */
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+/** Repo root (parent of `.sandcastle/`) — the child's cwd, so the orchestrator's
+ *  relative prompt/session paths (`./.sandcastle/…`) resolve as they do headless. */
+const REPO_ROOT = path.dirname(THIS_DIR);
+const ORCHESTRATOR_ENTRY = path.join(THIS_DIR, "main.mts");
+/** Local bin dir, prepended to the child's PATH so `tsx` resolves even when the
+ *  Cockpit was launched without pnpm putting `node_modules/.bin` on PATH. */
+const BIN_DIR = path.join(REPO_ROOT, "node_modules", ".bin");
+
+/** Cap on the scrolling event log (bounded ring; oldest entries fall off). */
+const LOG_CAP = 1000;
+
+/** The Live tab's supervised-child status. Launches `idle`; `running` while a
+ *  child is alive; `stopped` after a clean Stop/exit; `crashed` after an
+ *  unexpected exit (surfaced, never fatal to the Cockpit). */
+type ChildStatus = "idle" | "running" | "stopped" | "crashed";
+
+/** One rendered line in the scrolling event log, with optional colour/dim. */
+interface LogEntry {
+  readonly text: string;
+  readonly color?: string;
+  readonly dim?: boolean;
+}
+
+/** Human tab labels for the tab bar (ids are lowercase in `COCKPIT_TABS`). */
+const TAB_LABELS: Record<CockpitTab, string> = {
+  live: "Live",
+  sessions: "Sessions",
+  maintenance: "Maintenance",
+};
+
+/** Wall-clock `HH:MM:SS` prefix for a log line, from an event's ISO `ts`. */
+function clock(ts: string): string {
+  const d = new Date(ts);
+  return Number.isNaN(d.getTime()) ? "--:--:--" : d.toLocaleTimeString("en-GB", { hour12: false });
+}
+
+/** Turn one parsed orchestrator event into a coloured log entry: failures red,
+ *  soft warnings yellow, everything else default. The line text is the pure,
+ *  tested `formatEventLog`; only the colour choice is presentational. */
+function eventEntry(ev: OrchestratorEvent): LogEntry {
+  const failure =
+    ev.type === "gh-error" ||
+    ev.type === "planner-failed" ||
+    (ev.type === "session-resolved" && ev.status === "failed");
+  const warn = ev.type === "noop-escalated" || ev.type === "planner-no-plan";
+  return {
+    text: `${clock(ev.ts)}  ${formatEventLog(ev)}`,
+    color: failure ? "red" : warn ? "yellow" : undefined,
+  };
+}
+
+/** How the Cockpit launches the orchestrator: `tsx main.mts` in NDJSON mode,
+ *  from the repo root, with `node_modules/.bin` on PATH so `tsx` resolves even
+ *  when launched outside a pnpm script, and colour disabled so the child's
+ *  stderr prose stays clean in the log. Passed to the tested `spawnOrchestrator`. */
+const ORCHESTRATOR_SPAWN = {
+  command: "tsx",
+  args: [ORCHESTRATOR_ENTRY],
+  cwd: REPO_ROOT,
+  env: {
+    ...process.env,
+    SANDCASTLE_EVENT_FORMAT: "ndjson",
+    PATH: `${BIN_DIR}${path.delimiter}${process.env.PATH ?? ""}`,
+    FORCE_COLOR: "0",
+  },
+} as const;
+
+/** The tab bar: the active tab bracketed + highlighted, the rest dim. */
+function TabBar({ tab }: { tab: CockpitTab }): React.ReactElement {
+  return (
+    <Box flexDirection="row">
+      {COCKPIT_TABS.map((t) => {
+        const active = t === tab;
+        return (
+          <Box key={t} marginRight={1}>
+            <Text bold={active} color={active ? "cyan" : undefined} dimColor={!active}>
+              {active ? `[${TAB_LABELS[t]}]` : ` ${TAB_LABELS[t]} `}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+/** Colour for the Live status word, by child status. */
+function statusColor(status: ChildStatus): string {
+  switch (status) {
+    case "running":
+      return "green";
+    case "crashed":
+      return "red";
+    case "stopped":
+      return "yellow";
+    case "idle":
+      return "gray";
+  }
+}
+
+/** The Live tab: status/Start-Stop header + the scrolling event log. */
+function LiveTab({
+  status,
+  statusMessage,
+  log,
+  height,
+}: {
+  status: ChildStatus;
+  statusMessage: string;
+  log: LogEntry[];
+  /** Max event-log rows to render (terminal-bounded; the log tail-follows). */
+  height: number;
+}): React.ReactElement {
+  const action = status === "running" ? "Stop" : "Start";
+  const visible = log.slice(Math.max(0, log.length - Math.max(1, height)));
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      <Box flexDirection="row">
+        <Text>orchestrator: </Text>
+        <Text bold color={statusColor(status)}>
+          {status}
+        </Text>
+        <Text dimColor> — {statusMessage}</Text>
+        <Text dimColor> · Enter to {action}</Text>
+      </Box>
+      <Box
+        flexDirection="column"
+        flexGrow={1}
+        marginTop={1}
+        borderStyle="single"
+        borderColor="cyan"
+      >
+        <Text bold>
+          Event log <Text dimColor>({log.length})</Text>
+        </Text>
+        {visible.length === 0 ? (
+          <Text dimColor>idle — no events yet. Press Enter to Start the orchestrator.</Text>
+        ) : (
+          visible.map((entry, i) => (
+            <Text key={i} wrap="truncate-end" color={entry.color} dimColor={entry.dim}>
+              {entry.text === "" ? " " : entry.text}
+            </Text>
+          ))
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+/** A placeholder tab (Sessions / Maintenance) — named, with its standalone route. */
+function PlaceholderTab({ title, hint }: { title: string; hint: string }): React.ReactElement {
+  return (
+    <Box flexDirection="column" flexGrow={1} borderStyle="single" borderColor="gray" marginTop={1}>
+      <Text bold>{title}</Text>
+      <Text dimColor>Coming soon in the Cockpit.</Text>
+      <Text dimColor>{hint}</Text>
+    </Box>
+  );
+}
+
+/** Top-level Cockpit frame: owns the tab + supervised-child state and input. */
+function Cockpit(): React.ReactElement {
+  const { exit } = useApp();
+  const { isRawModeSupported } = useStdin();
+  const { stdout } = useStdout();
+  const inputActive = isRawModeSupported === true;
+
+  const [tab, setTab] = useState<CockpitTab>("live");
+  const [status, setStatus] = useState<ChildStatus>("idle");
+  const [statusMessage, setStatusMessage] = useState("not started");
+  const [log, setLog] = useState<LogEntry[]>([]);
+
+  // The live supervisor (null when no child is running). A ref, not state, so
+  // the async stdout/exit handlers always see the current child without stale
+  // closures and toggling it never triggers a re-render on its own.
+  const supervisorRef = useRef<Supervisor | null>(null);
+
+  const pushLog = useCallback((entry: LogEntry) => {
+    setLog((l) => appendLogLine(l, entry, LOG_CAP));
+  }, []);
+
+  /** Start the orchestrator child (no-op if one is already running). */
+  const start = useCallback(() => {
+    if (supervisorRef.current) return;
+    setStatus("running");
+    setStatusMessage("running");
+    pushLog({ text: "▶ started orchestrator (tsx main.mts)", color: "cyan" });
+    supervisorRef.current = spawnOrchestrator(ORCHESTRATOR_SPAWN, {
+      onEvent: (ev) => pushLog(eventEntry(ev)),
+      onStdoutRaw: (line) => pushLog({ text: line, dim: true }),
+      onStderr: (line) => pushLog({ text: line, dim: true }),
+      onExit: (exitStatus, message) => {
+        supervisorRef.current = null;
+        setStatus(exitStatus);
+        setStatusMessage(message);
+        pushLog({
+          text: `${exitStatus === "crashed" ? "✗" : "■"} ${message}`,
+          color: exitStatus === "crashed" ? "red" : "yellow",
+        });
+      },
+      onSpawnError: (message) => {
+        supervisorRef.current = null;
+        setStatus("crashed");
+        setStatusMessage(`failed to start: ${message}`);
+        pushLog({ text: `✗ failed to start orchestrator: ${message}`, color: "red" });
+      },
+    });
+  }, [pushLog]);
+
+  /** Stop the running orchestrator child (no-op if none). */
+  const stop = useCallback(() => {
+    if (!supervisorRef.current) return;
+    setStatusMessage("stopping…");
+    supervisorRef.current.stop();
+  }, []);
+
+  /** Quit the Cockpit, stopping any running child first (`q` / Ctrl-C). */
+  const quit = useCallback(() => {
+    supervisorRef.current?.stop();
+    void exit();
+  }, [exit]);
+
+  // Safety net: if the Cockpit unmounts for any other reason, don't orphan the
+  // child — SIGTERM it on teardown.
+  useEffect(() => () => supervisorRef.current?.stop(), []);
+
+  useInput(
+    (input, key) => {
+      if (input === "q" || (key.ctrl && input === "c")) {
+        quit();
+        return;
+      }
+      if (key.leftArrow) {
+        setTab((t) => cycleTab(t, "prev"));
+        return;
+      }
+      if (key.rightArrow) {
+        setTab((t) => cycleTab(t, "next"));
+        return;
+      }
+      // Enter toggles Start/Stop, but only on the Live tab (the only functional
+      // one this slice); it is inert on the placeholder tabs.
+      if (key.return && tab === "live") {
+        if (status === "running") stop();
+        else start();
+      }
+    },
+    { isActive: inputActive }
+  );
+
+  // Event-log viewport: terminal rows minus the surrounding chrome (tab bar,
+  // status line, log-box border + header, footer). A sane default keeps the
+  // slice math total when stdout has no rows (non-TTY).
+  const termRows = stdout?.rows;
+  const logHeight = termRows ? Math.max(3, termRows - 10) : 20;
+
+  return (
+    <Box flexDirection="column">
+      <TabBar tab={tab} />
+      <Box flexDirection="column" flexGrow={1} marginTop={1}>
+        {tab === "live" ? (
+          <LiveTab status={status} statusMessage={statusMessage} log={log} height={logHeight} />
+        ) : tab === "sessions" ? (
+          <PlaceholderTab title="Sessions" hint="Standalone: `pnpm sandcastle:browse`" />
+        ) : (
+          <PlaceholderTab title="Maintenance" hint="Standalone: `pnpm sandcastle:prune`" />
+        )}
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>←/→ switch tab · Enter Start/Stop · q quit</Text>
+      </Box>
+    </Box>
+  );
+}
+
+async function main(): Promise<void> {
+  const instance = render(<Cockpit />);
+  await instance.waitUntilExit();
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exitCode = 1;
+});

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,6 +53,10 @@ _Avoid_: lock, lease.
 One iteration of the persistent orchestrator loop: every ~60s, if the Pool has a free slot, query the Dispatch buckets and fill free slots by priority. When the Pool is full the `gh` query is skipped entirely; when all buckets are empty the tick is the idle sleep. A freed slot idles at most one tick (~60s) before being refilled. A Poll tick is **not** a Run and has no `runId`.
 _Avoid_: iteration, run, cycle.
 
+**Plan cache**:
+The orchestrator's **in-memory** record of the Planner's last emit list (the unblocked issues `U`), keyed by a content-hash of the `ready-for-agent` issue set — `hash(sorted [(number, updatedAt)])` over the raw `gh issue list --label ready-for-agent` result the Planner reasons over. While the key is unchanged, a Poll tick dispatches from the cached emit with **no Planner (Opus) call**; the Planner is re-invoked only when the key changes (an issue labeled in/out, or a body/label/comment edit). In-flight/PR state is checked live and is **not** in the key, so the cache stays valid across a blocker's whole Run (implement→review→merge). Non-durable — cold after restart (one re-plan), like the In-flight set (ADR-0006, ADR-0010). A cache hit still runs the pure dispatch (`pickImplementers`) over the cached emit, so capped-but-unblocked issues are never starved. Stores only the emit list, not the blocking graph.
+_Avoid_: plan graph, dependency graph, Planner memo, memoization.
+
 **`ready-for-human`**:
 The universal terminal label — on an issue or a PR — meaning "out of all Dispatch buckets; a human owns it." Every give-up / failure path lands here: a no-op Implementer (strips `ready-for-agent`, adds `ready-for-human`), a Reviewer that can't pass a change (leaves it draft, adds `ready-for-human`), and a Merger whose test-then-merge fails or conflicts (removes `reviewed`, reverts the PR to draft, adds `ready-for-human`). This is what keeps the persistent loop from re-dispatching un-actionable work forever.
 _Avoid_: blocked, stuck, wontfix (a distinct triage label).

--- a/docs/adr/0006-persistent-shared-pool-orchestrator.md
+++ b/docs/adr/0006-persistent-shared-pool-orchestrator.md
@@ -53,6 +53,8 @@ Each Poll tick (~60s):
   Running Opus to produce a plan we can't dispatch is pure token waste, and
   avoiding it is the stated motivation. The emit list is **not cached**: the
   Planner re-plans every eligible tick (accepted cost, for simplicity).
+  _Revised by ADR-0010:_ the emit list is now cached (the **Plan cache**) and
+  the Planner re-runs only when the `ready-for-agent` set's content changes.
 
 - **A Pool slot is a full agent+sandbox lifecycle.** Because impl and review are now
   decoupled across ticks, the Reviewer can no longer reuse the Implementer's live

--- a/docs/adr/0010-plan-cache-skips-planner-while-ready-set-unchanged.md
+++ b/docs/adr/0010-plan-cache-skips-planner-while-ready-set-unchanged.md
@@ -1,0 +1,180 @@
+# Plan cache: the orchestrator caches the Planner's emit list and skips the LLM while the ready-set is unchanged
+
+The persistent orchestrator (ADR-0006) re-runs the LLM **Planner** on every
+eligible **Poll tick** — its emit list is deliberately **not cached**
+("re-plans every eligible tick (accepted cost, for simplicity)"). This ADR pays
+down that accepted cost. The orchestrator now keeps a **Plan cache**: the
+Planner's last emit list, keyed by a content-hash of the `ready-for-agent`
+issue set. While that set is unchanged, the orchestrator dispatches from the
+cached list with **zero LLM calls**, and only re-invokes the Planner when the
+set actually changes. This **revises** ADR-0006's "emit list is not cached"
+decision; nothing else in ADR-0006 changes.
+
+## Why
+
+With `ready-for-agent` issues A, B, C where B and C are **blocked by** A, and A
+already dispatched (an Implementer running, then an open draft PR, then review,
+then merge):
+
+1. `filterReadyForAgent` drops A (in-flight or open-PR) → `actionable = {B, C}`,
+   non-empty.
+2. `shouldRunPlanner({B,C}, free>0)` is `true` — it only checks that the
+   actionable set is non-empty and a slot is free; it cannot see _why_ the set
+   is non-empty.
+3. The Planner re-queries `gh issue list --label ready-for-agent`, sees the full
+   `{A, B, C}` (A **keeps** `ready-for-agent` and stays `open` its whole
+   lifecycle), correctly reasons B and C are blocked by A, and emits **A** — the
+   only unblocked issue (see plan-prompt.md: when everything is blocked it still
+   emits the single highest-priority candidate, so the emit is essentially never
+   empty).
+4. The orchestrator filters the emitted A out (in-flight / open-PR) and
+   dispatches nothing.
+
+That is a full Opus Planner Session producing an undispatchable plan, repeated
+**every ~60s for the entire lifetime of A's Run** (implement → review → merge).
+The stated goal of the ADR-0006 Planner gate — "don't spend Opus on a plan we
+can't dispatch" — is defeated in exactly this shape.
+
+## The load-bearing invariant this must not break
+
+The design's correctness rests on a currently-undocumented invariant:
+
+> An in-flight or open-PR `ready-for-agent` issue **retains its
+> `ready-for-agent` label and stays `open`** through its whole Run
+> (implement → review → merge). Only merging (which closes the issue) or a
+> terminal `ready-for-human` escalation removes it from the Planner's query.
+
+This is what keeps the Planner _seeing_ A while A is in flight, so it correctly
+concludes B is blocked. Any "optimization" that strips `ready-for-agent` the
+moment A is dispatched would make the Planner stop seeing A, conclude B is
+**unblocked**, and **misdispatch blocked work** onto a conflicting branch. The
+Plan cache is therefore **purely additive** — a gate placed _before_ the Planner
+call. It never touches labels; when the Planner does run, it still receives the
+full `{A, B, C}` and reasons exactly as before.
+
+## Decision — the Plan cache
+
+The orchestrator keeps one in-memory value beside the **In-flight set**:
+
+```
+plan cache = { key: string, emit: EmittedIssue[] } | null
+```
+
+- **`emit`** is the Planner's last output `U` — the unblocked issues it emitted
+  (`{number, title, branch}`), _only_ the emit list. The blocking edges stay
+  internal to the Planner's reasoning; the orchestrator never needs to know
+  _who_ blocks _whom_, only _which_ issues are safe to start.
+- **`key`** is a content-hash of the **Planner's input set** — the raw
+  `gh issue list --state open --label ready-for-agent` result — as
+  `hash(sorted [(number, updatedAt)])`. GitHub bumps an issue's `updatedAt` on
+  any edit, comment, or label change, so the key changes on **any** add/remove
+  of a `ready-for-agent` issue or **any** content change the Planner reasons
+  over. In-flight/PR state is **not** in the key.
+
+Each Poll tick, at the implement stage (after the merge and review buckets have
+drained their slots, per ADR-0006's priority drain), when actionable issues
+exist and a slot remains:
+
+1. Compute `key` from the **raw** `readyForAgent` query result (before
+   `filterReadyForAgent`).
+2. **Cache hit** (`key === cache.key`): dispatch from `cache.emit` with **no
+   Planner call**. `dispatchable = emit − in-flight − open-PR`; `pickImplementers`
+   caps it at the free slots. Usually empty (the waste case: `emit = {A}`, A
+   in-flight → nothing) — but not always (see starvation below).
+3. **Cache miss** (no cache, or `key` changed): run the Planner, store
+   `{ key, emit }`, then dispatch as in step 2.
+
+The Planner LLM therefore runs **only when the `ready-for-agent` set's content
+changes** — a new issue labeled in, one merged/closed out, or a body/label/comment
+edit — never on a pure Poll tick where nothing moved.
+
+### Why the key hashes the raw set, not `actionable`
+
+The cached `emit` is the unblocked subset of the Planner's **input** — the full
+`ready-for-agent` open set `{A, B, C}` — so its validity depends on that set,
+not on the post-filter `actionable` (`{B, C}`). Keying on `actionable` would go
+stale silently: when A **merges**, A leaves the Planner's query so `emit` should
+be recomputed, yet `actionable` can stay `{B, C}` (B, C unchanged), the key
+wouldn't move, and the orchestrator would keep serving a stale `emit = {A}`.
+Hashing the raw set makes A's merge (issue closes → leaves the query) flip the
+key and force a re-plan, which is exactly when B and C become unblocked.
+
+### Cache hits still dispatch — they do not skip dispatch
+
+The gate skips the **LLM call**, not the dispatch. This is load-bearing and is
+where naïve "skip the Planner when inputs are unchanged" memoization is _wrong_:
+
+> `emit = {A, D, E}` (three independent unblocked issues), only **1** free slot.
+> Tick 1 dispatches A; `pickImplementers` caps at 1, dropping D and E _this
+> tick_. Tick 2: ready-set unchanged → cache hit. If we _skipped dispatch_, D
+> and E would **starve** despite free slots. Instead we re-run
+> `pickImplementers` over the cached `emit`, dispatch D and E, still **no Opus**.
+
+Today's every-tick Planner avoids this starvation only by paying the full LLM
+cost each tick. The Plan cache keeps the correctness and drops the cost.
+
+## Considered options
+
+- **Naïve memoization — "skip the Planner if inputs are unchanged."**
+  _Rejected._ Skipping _dispatch_ starves capped-but-unblocked issues (above).
+  The fix — skip the LLM but still dispatch from the cached emit — is the design
+  above.
+- **Key on ready-set + In-flight set** (the shape first sketched). _Rejected._
+  Including in-flight re-fires the Planner every time A flips
+  Implementer → Reviewer → Merger, because those flips churn the in-flight set
+  while the ready-set is unchanged — leaving most of the waste on the table.
+  Keying on ready-set content only, and checking in-flight/open-PR _live_ each
+  tick (both already queried), eliminates waste across A's **entire** Run.
+- **Key on issue numbers only** (no `updatedAt`). _Rejected._ The Planner
+  reasons over issue **body and comments**; an edit that changes the dependency
+  structure must re-plan. `updatedAt` is the cheap content marker that captures
+  it without fetching bodies into the key.
+- **Cache the full blocking graph, orchestrator reasons over edges.**
+  _Rejected as unnecessary._ The dispatch decision needs only "which issues are
+  safe to start" = the emit list. Edges would add a shared structure with an
+  update protocol (staleness, crash-before-write) for no dispatch benefit; the
+  whole-set content-hash is a conservative, correct staleness signal without
+  them.
+- **Durable cache (local file / GitHub).** _Rejected._ Consistent with ADR-0006's
+  in-memory In-flight philosophy, the Plan cache is **in-memory and
+  non-durable**. On process restart it is cold, so the first eligible tick
+  re-plans once — at-least-once, harmless, no external store.
+
+## Consequences
+
+- **Opus Planner Sessions drop from one-per-eligible-tick to one-per-ready-set-change.**
+  For the motivating case (A blocking B, C through a full implement→review→merge
+  Run of, say, 20+ ticks), that is one Planner Session instead of 20+. This
+  supersedes the grilling-session scope of "in-flight only": because the
+  `ready-for-agent` set is identical across all of A's phases (A keeps its label
+  and stays open), the cached emit stays valid across the **entire** Run for
+  free — no extra code narrows it back, and B genuinely stays blocked until A
+  lands on `main`.
+- **No new starvation and no new misdispatch.** Cache hits still run the pure
+  `pickImplementers` dispatch over the cached emit (no starvation), and the gate
+  never strips labels, so the Planner still sees in-flight blockers and never
+  misdispatches blocked work (invariant above).
+- **`queryReadyForAgent` must fetch `updatedAt`.** It currently requests
+  `number,title,labels`; the key needs `updatedAt` added to the `--json` fields
+  and to the `ReadyForAgentIssue` shape. `title`/`branch` on the cached emit are
+  unaffected.
+- **Restart re-plans once.** Cold cache after a crash/restart → one Planner
+  Session on the first eligible tick, then steady state. Accepted.
+- **Caching an LLM output does not add a correctness risk.** Reusing the prior
+  emit for an unchanged input is _more_ consistent than re-rolling the Planner;
+  a wrong emit is a pre-existing Planner risk, not one the cache introduces.
+- **Two-query race is accepted, as elsewhere in ADR-0006.** The key comes from
+  the orchestrator's `queryReadyForAgent`; the Planner re-queries independently.
+  If the set changes between the two, the cache self-corrects on the next tick.
+
+## Implementation notes (non-binding)
+
+- The gate belongs in `dispatch.mts` as pure/injectable functions with unit
+  tests in `dispatch.test.mts` (mirroring `shouldRunPlanner`, `pickImplementers`):
+  e.g. a `planCacheKey(readyForAgentIssues)` producing the stable hash, and a
+  predicate that, given the current key and the cache, returns either
+  "reuse cached emit" or "re-plan". The cache value itself lives in `main.mts`
+  beside the In-flight set (like `inflight`), not in the pure layer.
+- The dispatch from a cache hit reuses the **existing** `pickImplementers` +
+  `openPrIssues`/`inflight` filters unchanged — only the _source_ of the emit
+  list (cache vs. fresh Planner) differs.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "sandcastle:build-image": "sandcastle docker build-image",
     "sandcastle": "sandcastle docker build-image && tsx .sandcastle/main.mts",
     "sandcastle:browse": "tsx .sandcastle/session-browser.tsx",
+    "sandcastle:cockpit": "tsx .sandcastle/cockpit.tsx",
     "sandcastle:prune": "tsx .sandcastle/prune.mts",
     "prepare": "node scripts/link-git-hooks.js"
   },


### PR DESCRIPTION
Closes #80.

The foundational **Cockpit** tracer bullet (ADR-0008): a single Ink TUI that consolidates the Sandcastle surfaces into tabbed modes — **[Live] [Sessions] [Maintenance]** — launching **idle**. `←`/`→` cycle tabs; `q` / Ctrl-C quit cleanly, stopping any child first.

The **Live** tab is functional this slice. It supervises the orchestrator as a **child process** (never in-process — a throw in its loop must not take the Cockpit down): **Enter** Starts `tsx main.mts` in NDJSON mode (#78), parses its structured **Live feed** line-by-line, and renders it as a **scrolling event log**; Enter again **Stops** it (SIGTERM); a crash/exit is surfaced in the UI without killing the Cockpit. **Sessions**/**Maintenance** are placeholder tabs. Headless `pnpm sandcastle` still runs the orchestrator loop directly.

## Design

- **`.sandcastle/cockpit-core.mts`** — all the logic, pure & unit-tested (27 tests):
  - `COCKPIT_TABS` + `cycleTab` — the ←/→ tab model (forward/back, wraps)
  - `splitNdjsonChunk` + `parseEventLine` — reassemble the child's NDJSON stdout across chunk boundaries → typed `OrchestratorEvent` (null on blank/garbage/unknown-type)
  - `formatEventLog` — a **total** compact one-liner formatter (surfaces *successful* resolutions, which the headless prose renderer suppresses)
  - `appendLogLine` — bounded ring buffer for the log
  - `describeChildExit` — clean **stopped** vs **crashed** classification
  - `spawnOrchestrator` — the supervisor, with an injectable spawn config so it's **integration-tested against a real child process**
- **`.sandcastle/cockpit.tsx`** — the thin Ink layer only, untested per `CODING_STANDARDS.md` (like `session-browser.tsx`). Imported as `./cockpit-core.mjs` so tsc resolves the `.mts` source.
- **`package.json`** — adds `pnpm sandcastle:cockpit`.

## Acceptance criteria

- [x] Idle launch with `[Live] [Sessions] [Maintenance]` + working tab-switch keybind
- [x] Live Start spawns the orchestrator as a child; Stop terminates it; restart works
- [x] Child NDJSON events render as a scrolling event log
- [x] A child crash/exit is surfaced without killing the Cockpit
- [x] `q` / Ctrl-C quits, stopping any running child first
- [x] Sessions/Maintenance placeholder tabs

## Verification

- **27 unit + integration tests** pass (`cockpit-core.test.mts`), typecheck + lint clean.
- Supervisor pipeline proven end-to-end against a **real spawned child** (fake NDJSON emitter): decode across a mid-JSON chunk split, stderr separation, Stop→`stopped`, spawn-failure surfaced.
- Ink shell **smoke-rendered** (idle Live tab), and the real Cockpit **driven through a PTY**: forward+backward tab cycling with wraparound, placeholder tabs, and clean `q` exit (code 0).
- The **real** `main.mts` was deliberately not run (it would dispatch live agents/Docker); its spawn config is verified to resolve and the supervisor it feeds is real-child-tested.

Blocked-by #78 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)