### PR TITLE
#81 Cockpit Live tab: pool gauge + in-flight list from event stream

### DIFF
--- a/.sandcastle/cockpit-core.mts
+++ b/.sandcastle/cockpit-core.mts
@@ -307,6 +307,94 @@ export function spawnOrchestrator(config: SpawnConfig, handlers: OrchestratorHan
   };
 }
 
+/** One currently-running Session in the Live tab's in-flight list: an issue and
+ *  the **phase** (role) whose Session is running for it. Derived purely from the
+ *  structured event stream — an entry is added on `dispatch` and removed on
+ *  `session-resolved` (never from the Manifest, which only gains a row *after* a
+ *  Session resolves, ADR-0008). */
+export interface InFlightEntry {
+  readonly issue: number;
+  readonly role: "implementer" | "reviewer" | "merger";
+  /** The PR under review/merge; null for an Implementer (no PR yet). */
+  readonly pr: number | null;
+  /** The issue title (Implementer dispatch only; null for Reviewer/Merger). */
+  readonly title: string | null;
+}
+
+/** The Live tab's derived monitor state: the in-flight list plus the Pool size.
+ *  Everything the pool gauge and in-flight list render folds out of the event
+ *  stream into this — see {@link reduceLiveEvent}. */
+export interface LiveView {
+  /** Currently-running Sessions, one per issue, in dispatch order. */
+  readonly inflight: readonly InFlightEntry[];
+  /** Pool capacity (`POOL_SIZE`), learned from the first `tick`; null until then. */
+  readonly poolSize: number | null;
+}
+
+/** The zero state a fresh (or freshly restarted) Live monitor folds from. */
+export const EMPTY_LIVE_VIEW: LiveView = { inflight: [], poolSize: null };
+
+/**
+ * Fold one orchestrator event into the Live monitor view — the pure reducer
+ * behind the pool gauge and in-flight list (issue #81; ADR-0008). Only three
+ * event types move the view:
+ *
+ * - `dispatch` **adds** an in-flight entry, keyed by issue number so an issue
+ *   moving implement→review→merge replaces its phase in place (mirrors the
+ *   orchestrator's issue/PR-keyed In-flight set, CONTEXT.md) rather than stacking
+ *   duplicates.
+ * - `session-resolved` **removes** the entry for that issue.
+ * - `tick` captures `poolSize` for the gauge's denominator.
+ *
+ * Every other event leaves the view untouched (returned unchanged, same
+ * reference). Pure (view in, new view out; never mutates `view`) so the whole
+ * event→gauge/list derivation is unit-testable without the Ink layer.
+ */
+export function reduceLiveEvent(view: LiveView, event: OrchestratorEvent): LiveView {
+  switch (event.type) {
+    case "dispatch": {
+      const rest = view.inflight.filter((e) => e.issue !== event.issue);
+      const entry: InFlightEntry = {
+        issue: event.issue,
+        role: event.role,
+        pr: event.pr,
+        title: event.title,
+      };
+      return { ...view, inflight: [...rest, entry] };
+    }
+    case "session-resolved":
+      return { ...view, inflight: view.inflight.filter((e) => e.issue !== event.issue) };
+    case "tick":
+      return { ...view, poolSize: event.poolSize };
+    default:
+      return view;
+  }
+}
+
+/**
+ * The pool gauge label: how many Pool slots are busy vs total, `N / POOL_SIZE`.
+ * Busy is the derived in-flight count (kept in lock-step with the list), and the
+ * total is the Pool size learned from `tick` — rendered `?` until the first tick
+ * reports it. Pure so the exact string is unit-testable.
+ */
+export function formatPoolGauge(view: LiveView): string {
+  const total = view.poolSize === null ? "?" : String(view.poolSize);
+  return `${view.inflight.length} / ${total} busy`;
+}
+
+/**
+ * Render one in-flight entry as a compact `phase · what` line for the in-flight
+ * list: an Implementer shows its issue + title (`impl #12 · Add the widget`), a
+ * Reviewer/Merger shows the PR it is acting on (`rev PR #90 (#44)`). Pure so the
+ * exact strings are unit-testable.
+ */
+export function formatInFlight(entry: InFlightEntry): string {
+  if (entry.role === "implementer") {
+    return `impl #${entry.issue}${entry.title ? ` · ${entry.title}` : ""}`;
+  }
+  return `${roleAbbr(entry.role)} PR #${entry.pr} (#${entry.issue})`;
+}
+
 /** The compact role tag used in log lines: `impl` / `rev` / `merger`. Mirrors
  *  the labels the orchestrator's `lifecycle`/prose output already uses. */
 function roleAbbr(role: "implementer" | "reviewer" | "merger"): string {

--- a/.sandcastle/cockpit-core.test.mts
+++ b/.sandcastle/cockpit-core.test.mts
@@ -5,8 +5,12 @@ import {
   COCKPIT_TABS,
   cycleTab,
   describeChildExit,
+  EMPTY_LIVE_VIEW,
   formatEventLog,
+  formatInFlight,
+  formatPoolGauge,
   parseEventLine,
+  reduceLiveEvent,
   spawnOrchestrator,
   splitNdjsonChunk,
   type OrchestratorHandlers,
@@ -208,6 +212,184 @@ describe("appendLogLine", () => {
     const input = ["a", "b"];
     appendLogLine(input, "c", 5);
     expect(input).toEqual(["a", "b"]);
+  });
+});
+
+// ── reduceLiveEvent: the pure event→Live-view fold (pool gauge + in-flight) ──
+
+describe("reduceLiveEvent", () => {
+  it("adds an in-flight entry when a Session is dispatched", () => {
+    const view = reduceLiveEvent(
+      EMPTY_LIVE_VIEW,
+      evt({
+        type: "dispatch",
+        role: "implementer",
+        issue: 12,
+        branch: "sandcastle/issue-12",
+        pr: null,
+        title: "Add the widget",
+      })
+    );
+    expect(view.inflight).toEqual([
+      { issue: 12, role: "implementer", pr: null, title: "Add the widget" },
+    ]);
+  });
+
+  it("removes an in-flight entry when its Session resolves", () => {
+    const dispatched = reduceLiveEvent(
+      EMPTY_LIVE_VIEW,
+      evt({
+        type: "dispatch",
+        role: "implementer",
+        issue: 12,
+        branch: "sandcastle/issue-12",
+        pr: null,
+        title: "Add the widget",
+      })
+    );
+    const resolved = reduceLiveEvent(
+      dispatched,
+      evt({
+        type: "session-resolved",
+        role: "implementer",
+        issue: 12,
+        branch: "sandcastle/issue-12",
+        status: "ok",
+        commits: 2,
+        error: null,
+      })
+    );
+    expect(resolved.inflight).toEqual([]);
+  });
+
+  it("removes on resolution regardless of outcome (a FAILED Session too)", () => {
+    const dispatched = reduceLiveEvent(
+      EMPTY_LIVE_VIEW,
+      evt({ type: "dispatch", role: "reviewer", issue: 44, branch: "b", pr: 90, title: null })
+    );
+    const resolved = reduceLiveEvent(
+      dispatched,
+      evt({
+        type: "session-resolved",
+        role: "reviewer",
+        issue: 44,
+        branch: "b",
+        status: "failed",
+        commits: 0,
+        error: "boom",
+      })
+    );
+    expect(resolved.inflight).toEqual([]);
+  });
+
+  it("keeps one entry per issue: a later phase replaces the earlier in place", () => {
+    let view = reduceLiveEvent(
+      EMPTY_LIVE_VIEW,
+      evt({ type: "dispatch", role: "implementer", issue: 12, branch: "b", pr: null, title: "T" })
+    );
+    view = reduceLiveEvent(
+      view,
+      evt({ type: "dispatch", role: "reviewer", issue: 12, branch: "b", pr: 90, title: null })
+    );
+    expect(view.inflight).toEqual([{ issue: 12, role: "reviewer", pr: 90, title: null }]);
+  });
+
+  it("tracks several distinct issues in dispatch order", () => {
+    let view = reduceLiveEvent(
+      EMPTY_LIVE_VIEW,
+      evt({ type: "dispatch", role: "implementer", issue: 12, branch: "b", pr: null, title: "A" })
+    );
+    view = reduceLiveEvent(
+      view,
+      evt({ type: "dispatch", role: "merger", issue: 44, branch: "b", pr: 90, title: null })
+    );
+    expect(view.inflight.map((e) => e.issue)).toEqual([12, 44]);
+  });
+
+  it("captures the Pool size from a tick for the gauge denominator", () => {
+    const view = reduceLiveEvent(
+      EMPTY_LIVE_VIEW,
+      evt({ type: "tick", free: 3, poolSize: 10, inflight: 7 })
+    );
+    expect(view.poolSize).toBe(10);
+    expect(view.inflight).toEqual([]);
+  });
+
+  it("leaves the view unchanged (same reference) for unrelated events", () => {
+    const seeded = reduceLiveEvent(
+      EMPTY_LIVE_VIEW,
+      evt({ type: "dispatch", role: "implementer", issue: 12, branch: "b", pr: null, title: "A" })
+    );
+    const after = reduceLiveEvent(seeded, evt({ type: "pool-full" }));
+    expect(after).toBe(seeded);
+  });
+
+  it("ignores a resolution for an issue that is not in flight (no-op)", () => {
+    const seeded = reduceLiveEvent(
+      EMPTY_LIVE_VIEW,
+      evt({ type: "dispatch", role: "implementer", issue: 12, branch: "b", pr: null, title: "A" })
+    );
+    const after = reduceLiveEvent(
+      seeded,
+      evt({
+        type: "session-resolved",
+        role: "implementer",
+        issue: 99,
+        branch: "b",
+        status: "ok",
+        commits: 1,
+        error: null,
+      })
+    );
+    expect(after.inflight.map((e) => e.issue)).toEqual([12]);
+  });
+
+  it("does not mutate the input view", () => {
+    const input = EMPTY_LIVE_VIEW;
+    reduceLiveEvent(
+      input,
+      evt({ type: "dispatch", role: "implementer", issue: 12, branch: "b", pr: null, title: "A" })
+    );
+    expect(input.inflight).toEqual([]);
+  });
+});
+
+// ── formatPoolGauge: busy vs total slots, N / POOL_SIZE ──────────────────────
+
+describe("formatPoolGauge", () => {
+  it("shows busy over total once a tick has reported the Pool size", () => {
+    let view = reduceLiveEvent(
+      EMPTY_LIVE_VIEW,
+      evt({ type: "tick", free: 8, poolSize: 10, inflight: 2 })
+    );
+    view = reduceLiveEvent(
+      view,
+      evt({ type: "dispatch", role: "implementer", issue: 12, branch: "b", pr: null, title: "A" })
+    );
+    expect(formatPoolGauge(view)).toBe("1 / 10 busy");
+  });
+
+  it("renders the total as ? before the first tick reports the Pool size", () => {
+    expect(formatPoolGauge(EMPTY_LIVE_VIEW)).toBe("0 / ? busy");
+  });
+});
+
+// ── formatInFlight: one in-flight entry → a compact phase line ───────────────
+
+describe("formatInFlight", () => {
+  it("renders an Implementer with its issue and title", () => {
+    expect(
+      formatInFlight({ issue: 12, role: "implementer", pr: null, title: "Add the widget" })
+    ).toBe("impl #12 · Add the widget");
+  });
+
+  it("renders a Reviewer/Merger with the PR it is acting on", () => {
+    expect(formatInFlight({ issue: 44, role: "reviewer", pr: 90, title: null })).toBe(
+      "rev PR #90 (#44)"
+    );
+    expect(formatInFlight({ issue: 44, role: "merger", pr: 90, title: null })).toBe(
+      "merger PR #90 (#44)"
+    );
   });
 });
 

--- a/.sandcastle/cockpit.tsx
+++ b/.sandcastle/cockpit.tsx
@@ -10,11 +10,17 @@
  * process** (never in-process — a crash in the loop must not take the Cockpit
  * down, ADR-0008). Enter **Start**s `tsx main.mts` with
  * `SANDCASTLE_EVENT_FORMAT=ndjson`; the child's stdout is the structured
- * **Live feed** (NDJSON, from #78), parsed line-by-line and rendered as a
- * scrolling **event log**. Enter again **Stop**s it (SIGTERM); Start after a
- * stop/crash restarts. The child's stderr (the per-agent sub-feed + any crash
- * trace) is surfaced dimmed in the same log. A child crash/exit is reported in
- * the UI (status line + a coloured log line) without unmounting the Cockpit.
+ * **Live feed** (NDJSON, from #78), parsed line-by-line and rendered as the full
+ * orchestrator monitor (issue #81): a status/Start-Stop header, a **pool gauge**
+ * (`N / POOL_SIZE` busy), an **in-flight list** of currently-running issues +
+ * phases, and a scrolling **event log**. The gauge and in-flight list derive
+ * purely from the event stream via `reduceLiveEvent` — a `dispatch` adds an
+ * entry, a `session-resolved` removes it — never from the Manifest (which only
+ * gains a row *after* a Session resolves, ADR-0008). Enter again **Stop**s it
+ * (SIGTERM); Start after a stop/crash restarts (resetting the monitor). The
+ * child's stderr (the per-agent sub-feed + any crash trace) is surfaced dimmed
+ * in the same log. A child crash/exit is reported in the UI (status line + a
+ * coloured log line) without unmounting the Cockpit.
  *
  * **Sessions** and **Maintenance** are placeholder tabs in this slice (their
  * standalone commands, `sandcastle:browse` / `sandcastle:prune`, still work).
@@ -41,9 +47,14 @@ import {
   appendLogLine,
   COCKPIT_TABS,
   cycleTab,
+  EMPTY_LIVE_VIEW,
   formatEventLog,
+  formatInFlight,
+  formatPoolGauge,
+  reduceLiveEvent,
   spawnOrchestrator,
   type CockpitTab,
+  type LiveView,
   type Supervisor,
 } from "./cockpit-core.mjs";
 import type { OrchestratorEvent } from "./events.mjs";
@@ -150,15 +161,41 @@ function statusColor(status: ChildStatus): string {
   }
 }
 
-/** The Live tab: status/Start-Stop header + the scrolling event log. */
+/** The in-flight panel: the pool gauge (busy/total slots) over the list of
+ *  currently-running Sessions, all folded from the event stream into `view`. */
+function InFlightPanel({ view }: { view: LiveView }): React.ReactElement {
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor="gray">
+      <Box flexDirection="row">
+        <Text bold>Pool </Text>
+        <Text color="green">{formatPoolGauge(view)}</Text>
+      </Box>
+      {view.inflight.length === 0 ? (
+        <Text dimColor>no Sessions in flight</Text>
+      ) : (
+        view.inflight.map((entry) => (
+          <Text key={entry.issue} wrap="truncate-end">
+            · {formatInFlight(entry)}
+          </Text>
+        ))
+      )}
+    </Box>
+  );
+}
+
+/** The Live tab: status/Start-Stop header + pool gauge & in-flight list + the
+ *  scrolling event log. The gauge/list derive purely from the event stream via
+ *  `view` (never the Manifest — ADR-0008); the log is the same bounded ring. */
 function LiveTab({
   status,
   statusMessage,
+  view,
   log,
   height,
 }: {
   status: ChildStatus;
   statusMessage: string;
+  view: LiveView;
   log: LogEntry[];
   /** Max event-log rows to render (terminal-bounded; the log tail-follows). */
   height: number;
@@ -174,6 +211,9 @@ function LiveTab({
         </Text>
         <Text dimColor> — {statusMessage}</Text>
         <Text dimColor> · Enter to {action}</Text>
+      </Box>
+      <Box marginTop={1}>
+        <InFlightPanel view={view} />
       </Box>
       <Box
         flexDirection="column"
@@ -221,6 +261,9 @@ function Cockpit(): React.ReactElement {
   const [status, setStatus] = useState<ChildStatus>("idle");
   const [statusMessage, setStatusMessage] = useState("not started");
   const [log, setLog] = useState<LogEntry[]>([]);
+  // The derived Live monitor state (pool gauge + in-flight list), folded from
+  // the event stream by the pure `reduceLiveEvent` — never the Manifest.
+  const [view, setView] = useState<LiveView>(EMPTY_LIVE_VIEW);
 
   // The live supervisor (null when no child is running). A ref, not state, so
   // the async stdout/exit handlers always see the current child without stale
@@ -236,9 +279,13 @@ function Cockpit(): React.ReactElement {
     if (supervisorRef.current) return;
     setStatus("running");
     setStatusMessage("running");
+    setView(EMPTY_LIVE_VIEW); // fresh monitor for this run (in-flight is non-durable)
     pushLog({ text: "▶ started orchestrator (tsx main.mts)", color: "cyan" });
     supervisorRef.current = spawnOrchestrator(ORCHESTRATOR_SPAWN, {
-      onEvent: (ev) => pushLog(eventEntry(ev)),
+      onEvent: (ev) => {
+        setView((v) => reduceLiveEvent(v, ev));
+        pushLog(eventEntry(ev));
+      },
       onStdoutRaw: (line) => pushLog({ text: line, dim: true }),
       onStderr: (line) => pushLog({ text: line, dim: true }),
       onExit: (exitStatus, message) => {
@@ -311,7 +358,13 @@ function Cockpit(): React.ReactElement {
       <TabBar tab={tab} />
       <Box flexDirection="column" flexGrow={1} marginTop={1}>
         {tab === "live" ? (
-          <LiveTab status={status} statusMessage={statusMessage} log={log} height={logHeight} />
+          <LiveTab
+            status={status}
+            statusMessage={statusMessage}
+            view={view}
+            log={log}
+            height={logHeight}
+          />
         ) : tab === "sessions" ? (
           <PlaceholderTab title="Sessions" hint="Standalone: `pnpm sandcastle:browse`" />
         ) : (

--- a/.sandcastle/events.test.mts
+++ b/.sandcastle/events.test.mts
@@ -14,7 +14,10 @@ import {
  * formatters are exercised against stable inputs (the prose formatters ignore
  * `ts`; the NDJSON formatter includes it).
  */
-function evt(event: Omit<OrchestratorEvent, "ts">, ts = "2026-07-04T10:00:00.000Z"): OrchestratorEvent {
+function evt(
+  event: Omit<OrchestratorEvent, "ts">,
+  ts = "2026-07-04T10:00:00.000Z"
+): OrchestratorEvent {
   return { ...(event as object), ts } as OrchestratorEvent;
 }
 
@@ -22,12 +25,8 @@ function evt(event: Omit<OrchestratorEvent, "ts">, ts = "2026-07-04T10:00:00.000
 
 describe("formatEventProse", () => {
   it("reproduces the Poll-tick header (leading + trailing blank line)", () => {
-    const line = formatEventProse(
-      evt({ type: "tick", free: 3, poolSize: 10, inflight: 7 })
-    );
-    expect(line).toBe(
-      "\n=== Poll tick — 3/10 Pool slots free, 7 in-flight ===\n"
-    );
+    const line = formatEventProse(evt({ type: "tick", free: 3, poolSize: 10, inflight: 7 }));
+    expect(line).toBe("\n=== Poll tick — 3/10 Pool slots free, 7 in-flight ===\n");
   });
 
   it("reproduces the pool-full skip line", () => {
@@ -38,12 +37,8 @@ describe("formatEventProse", () => {
 
   it("reproduces the buckets counts line", () => {
     expect(
-      formatEventProse(
-        evt({ type: "buckets", merge: 1, review: 2, agent: 5, actionable: 3 })
-      )
-    ).toBe(
-      "buckets: ready-for-merge 1, ready-for-review 2, ready-for-agent 5 (3 actionable)."
-    );
+      formatEventProse(evt({ type: "buckets", merge: 1, review: 2, agent: 5, actionable: 3 }))
+    ).toBe("buckets: ready-for-merge 1, ready-for-review 2, ready-for-agent 5 (3 actionable).");
   });
 
   it("reproduces the Merger dispatch line (pr + issue + branch)", () => {
@@ -58,9 +53,7 @@ describe("formatEventProse", () => {
           title: null,
         })
       )
-    ).toBe(
-      "  → dispatching Merger for PR #90 (issue #44) → sandcastle/issue-44"
-    );
+    ).toBe("  → dispatching Merger for PR #90 (issue #44) → sandcastle/issue-44");
   });
 
   it("reproduces the Reviewer dispatch line", () => {
@@ -75,9 +68,7 @@ describe("formatEventProse", () => {
           title: null,
         })
       )
-    ).toBe(
-      "  → dispatching Reviewer for PR #90 (issue #44) → sandcastle/issue-44"
-    );
+    ).toBe("  → dispatching Reviewer for PR #90 (issue #44) → sandcastle/issue-44");
   });
 
   it("reproduces the Implementer dispatch line (title, no pr)", () => {
@@ -92,9 +83,7 @@ describe("formatEventProse", () => {
           title: "Fix the thing",
         })
       )
-    ).toBe(
-      "  → dispatching Implementer for #44: Fix the thing → sandcastle/issue-44"
-    );
+    ).toBe("  → dispatching Implementer for #44: Fix the thing → sandcastle/issue-44");
   });
 
   it("reproduces the Planner-emitted count line", () => {
@@ -116,9 +105,9 @@ describe("formatEventProse", () => {
   });
 
   it("reproduces the Planner-failed line", () => {
-    expect(
-      formatEventProse(evt({ type: "planner-failed", error: "boom" }))
-    ).toBe("Planner failed: boom");
+    expect(formatEventProse(evt({ type: "planner-failed", error: "boom" }))).toBe(
+      "Planner failed: boom"
+    );
   });
 
   it("reproduces the no-op Implementer escalation line", () => {
@@ -238,9 +227,9 @@ describe("eventStream", () => {
   it("routes the orchestrator progress events to stdout", () => {
     expect(eventStream(evt({ type: "tick", free: 1, poolSize: 10, inflight: 0 }))).toBe("stdout");
     expect(eventStream(evt({ type: "pool-full" }))).toBe("stdout");
-    expect(eventStream(evt({ type: "buckets", merge: 0, review: 0, agent: 0, actionable: 0 }))).toBe(
-      "stdout"
-    );
+    expect(
+      eventStream(evt({ type: "buckets", merge: 0, review: 0, agent: 0, actionable: 0 }))
+    ).toBe("stdout");
     expect(
       eventStream(
         evt({ type: "dispatch", role: "merger", issue: 1, branch: "b", pr: 2, title: null })
@@ -404,9 +393,7 @@ describe("createEvents", () => {
     });
     expect(out).not.toHaveBeenCalled();
     expect(err).toHaveBeenCalledTimes(1);
-    expect(err).toHaveBeenCalledWith(
-      "  ✗ rev #9 (sandcastle/issue-9) failed: kaboom"
-    );
+    expect(err).toHaveBeenCalledWith("  ✗ rev #9 (sandcastle/issue-9) failed: kaboom");
   });
 
   it("in ndjson mode writes every event as one JSON object to `out` (incl. silent-in-prose ones)", () => {
@@ -434,7 +421,13 @@ describe("createEvents", () => {
     const first = JSON.parse(out.mock.calls[0][0] as string) as Record<string, unknown>;
     const second = JSON.parse(out.mock.calls[1][0] as string) as Record<string, unknown>;
     const third = JSON.parse(out.mock.calls[2][0] as string) as Record<string, unknown>;
-    expect(first).toEqual({ type: "tick", free: 3, poolSize: 10, inflight: 7, ts: "2026-07-04T10:00:00.000Z" });
+    expect(first).toEqual({
+      type: "tick",
+      free: 3,
+      poolSize: 10,
+      inflight: 7,
+      ts: "2026-07-04T10:00:00.000Z",
+    });
     expect(second).toEqual({
       type: "session-resolved",
       role: "implementer",
@@ -445,7 +438,11 @@ describe("createEvents", () => {
       error: null,
       ts: "2026-07-04T10:00:00.000Z",
     });
-    expect(third).toEqual({ type: "planner-failed", error: "boom", ts: "2026-07-04T10:00:00.000Z" });
+    expect(third).toEqual({
+      type: "planner-failed",
+      error: "boom",
+      ts: "2026-07-04T10:00:00.000Z",
+    });
   });
 
   it("defaults to prose and reads the format from SANDCASTLE_EVENT_FORMAT when not given", () => {


### PR DESCRIPTION
Closes #81.

Enriches the Cockpit **Live tab** from a bare event log into the full orchestrator monitor described in `CONTEXT.md` (Cockpit) — seeing what agents are doing *right now*. Alongside the existing status header and event log, it adds a **pool gauge** and an **in-flight list**, all derived purely from the structured event stream (never the Manifest, per ADR-0008).

## What changed

**`cockpit-core.mts` — new pure, unit-tested logic**
- `reduceLiveEvent(view, event)` — folds the event stream into the Live view:
  - `dispatch` **adds** an in-flight entry, keyed by **issue number** so an issue moving implement→review→merge replaces its phase in place (mirrors the orchestrator's issue/PR-keyed In-flight set) rather than stacking duplicates.
  - `session-resolved` **removes** the entry (any outcome — ok or failed).
  - `tick` captures `poolSize` for the gauge denominator; every other event returns the view unchanged (same reference), never mutating input.
- `formatPoolGauge(view)` — `N / POOL_SIZE busy` (busy = derived in-flight length, so gauge and list stay in lock-step; total renders `?` until the first tick reports it).
- `formatInFlight(entry)` — `impl #12 · Add the widget` / `rev PR #90 (#44)`.
- New types: `InFlightEntry`, `LiveView`, `EMPTY_LIVE_VIEW`.

**`cockpit.tsx` — thin Ink layer (untested per CODING_STANDARDS)**
- Folds each `onEvent` through `reduceLiveEvent` into new `view` state; resets to `EMPTY_LIVE_VIEW` on Start (in-flight is non-durable).
- New `InFlightPanel` renders the pool gauge over the in-flight list; retains the existing idle/running/crashed status header.

## Acceptance criteria

- [x] Status header reflecting idle / running / crashed
- [x] Pool gauge showing busy vs total slots (`N / POOL_SIZE`)
- [x] In-flight list of currently-running issues + phases, updated from the event stream
- [x] In-flight entries added on `dispatch`, removed on `session-resolved` — sourced from events, not the Manifest
- [x] Pure event→view reducers unit-tested

## Testing

Built test-first (TDD, one behavior per red→green cycle). 13 new cases cover the reducer (add / remove / failed-remove / phase-replace / multi-issue / no-op / tick / immutability) and both formatters. All **277 sandcastle tests pass**; full-project typecheck is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)