### PR TITLE
#86 Plan cache: skip the Planner while the ready-for-agent set is unchanged

### DIFF
--- a/.sandcastle/cockpit-core.mts
+++ b/.sandcastle/cockpit-core.mts
@@ -80,6 +80,7 @@ const KNOWN_EVENT_TYPES = new Set<OrchestratorEvent["type"]>([
   "buckets",
   "dispatch",
   "planner-emitted",
+  "plan-reused",
   "planner-skipped",
   "planner-no-plan",
   "planner-failed",
@@ -175,6 +176,8 @@ export function formatEventLog(event: OrchestratorEvent): string {
       return `buckets · merge ${event.merge} · review ${event.review} · agent ${event.agent} (${event.actionable} actionable)`;
     case "planner-emitted":
       return `planner emitted ${event.count} issue(s)`;
+    case "plan-reused":
+      return `plan cache hit · reused ${event.count} issue(s) · no planner call`;
     case "planner-skipped":
       return "planner skipped";
     case "planner-no-plan":

--- a/.sandcastle/cockpit-core.test.mts
+++ b/.sandcastle/cockpit-core.test.mts
@@ -122,6 +122,11 @@ describe("parseEventLine", () => {
     });
   });
 
+  it("recognizes the plan-reused cache-hit event (#86)", () => {
+    const line = JSON.stringify({ type: "plan-reused", count: 3, ts: "x" });
+    expect(parseEventLine(line)).toEqual({ type: "plan-reused", count: 3, ts: "x" });
+  });
+
   it("returns null for a blank line", () => {
     expect(parseEventLine("")).toBeNull();
     expect(parseEventLine("   ")).toBeNull();
@@ -242,6 +247,9 @@ describe("formatEventLog", () => {
     ).toBe("buckets · merge 1 · review 2 · agent 5 (3 actionable)");
     expect(formatEventLog(evt({ type: "planner-emitted", count: 3 }))).toBe(
       "planner emitted 3 issue(s)"
+    );
+    expect(formatEventLog(evt({ type: "plan-reused", count: 2 }))).toBe(
+      "plan cache hit · reused 2 issue(s) · no planner call"
     );
     expect(formatEventLog(evt({ type: "planner-skipped" }))).toBe("planner skipped");
     expect(formatEventLog(evt({ type: "planner-no-plan" }))).toBe("planner produced no plan");

--- a/.sandcastle/dispatch.mts
+++ b/.sandcastle/dispatch.mts
@@ -89,13 +89,16 @@ export function createInflight(): Inflight {
 
 /**
  * A `ready-for-agent` issue as the Dispatch bucket sees it: its number, title,
- * and current labels (so an issue that ALSO carries `ready-for-human` can be
- * excluded without a second query).
+ * current labels (so an issue that ALSO carries `ready-for-human` can be
+ * excluded without a second query), and `updatedAt` — GitHub's ISO timestamp,
+ * bumped on any edit/comment/label change, which the Plan cache key hashes so a
+ * content change to an issue the Planner reasons over forces a re-plan (ADR-0010).
  */
 export interface ReadyForAgentIssue {
   readonly number: number;
   readonly title: string;
   readonly labels: ReadonlyArray<string>;
+  readonly updatedAt: string;
 }
 
 /**
@@ -173,6 +176,91 @@ export function pickImplementers<T extends { number: number }>(
     if (!inflight.has(item.number)) picked.push(item);
   }
   return picked;
+}
+
+/**
+ * An issue the Planner emitted as safe to start — the unblocked subset `U` of
+ * its input set. The Plan cache stores exactly this list (never the blocking
+ * graph): the orchestrator only needs *which* issues are safe to dispatch, not
+ * *who* blocks *whom* (ADR-0010).
+ */
+export interface EmittedIssue {
+  readonly number: number;
+  readonly title: string;
+  readonly branch: string;
+}
+
+/**
+ * The **Plan cache** (CONTEXT.md; ADR-0010): the Planner's last `emit` list
+ * keyed by a content-hash of the raw `ready-for-agent` set it reasoned over.
+ * `null` when cold (process start / no plan yet). In-memory / non-durable — it
+ * lives in `main.mts` beside the In-flight set, the pure key + reuse predicate
+ * live here.
+ */
+export type PlanCache = { readonly key: string; readonly emit: EmittedIssue[] } | null;
+
+/**
+ * Content-hash of the raw `ready-for-agent` set the Planner reasons over —
+ * `hash(sorted [(number, updatedAt)])` (ADR-0010). Sorting by number makes the
+ * key **order-independent** (`gh` list order must not matter); including
+ * `updatedAt` makes it change on any add/remove of an issue OR any edit/comment/
+ * label change (GitHub bumps `updatedAt`), and stay stable otherwise.
+ *
+ * IMPORTANT: callers must pass the **raw** `queryReadyForAgent` result (before
+ * `filterReadyForAgent`), never the post-filter `actionable` set — otherwise the
+ * cache goes stale silently when a blocker merges out of the query (ADR-0010).
+ *
+ * The "hash" is the canonical sorted-pairs JSON itself (a content-identity key):
+ * two sets compare equal iff they hold the same `(number, updatedAt)` pairs. A
+ * digest would only add opacity — the key is compared by string equality and is
+ * far more debuggable as the readable pair list.
+ */
+export function planCacheKey(issues: ReadonlyArray<{ number: number; updatedAt: string }>): string {
+  const pairs = issues.map((i) => [i.number, i.updatedAt] as const).sort((a, b) => a[0] - b[0]);
+  return JSON.stringify(pairs);
+}
+
+/**
+ * The reuse-vs-replan predicate (ADR-0010). Returns `true` — **reuse the cached
+ * emit, no Planner call** — only when the cache is warm AND its key matches the
+ * current raw-set key. Returns `false` — **re-plan** — when the cache is cold
+ * (`null`) or the key moved (an issue labeled in/out, or a content edit). Either
+ * way the caller still runs the pure `pickImplementers` dispatch over the emit,
+ * so a cache hit never skips dispatch and capped-but-unblocked issues never
+ * starve.
+ */
+export function shouldReusePlan(key: string, cache: PlanCache): boolean {
+  return cache !== null && cache.key === key;
+}
+
+/**
+ * Resolve the emit list to dispatch from this tick, running the injected
+ * `runPlanner` **only on a cache miss** (ADR-0010). Returns the emit, the
+ * (possibly updated) cache to store, and `plannerRan` so the caller can observe
+ * whether Opus was spent.
+ *
+ * - **Cache hit** (`shouldReusePlan`): serve `cache.emit` verbatim, `runPlanner`
+ *   is never called, cache is returned unchanged.
+ * - **Cache miss** (cold cache / key moved): call `runPlanner`, store
+ *   `{ key, emit }`, return the fresh emit.
+ *
+ * The caller passes the **raw** `queryReadyForAgent` result (before
+ * `filterReadyForAgent`) as `readyForAgent`, then runs the same
+ * `openPrIssues`/`inflight` filters + `pickImplementers` over the returned emit
+ * regardless of hit or miss — a cache hit skips the LLM, never the dispatch, so
+ * a capped emit still drains on later ticks (no starvation).
+ */
+export async function resolvePlanEmit(
+  readyForAgent: ReadonlyArray<{ number: number; updatedAt: string }>,
+  cache: PlanCache,
+  runPlanner: () => Promise<EmittedIssue[]>
+): Promise<{ emit: EmittedIssue[]; cache: PlanCache; plannerRan: boolean }> {
+  const key = planCacheKey(readyForAgent);
+  if (shouldReusePlan(key, cache)) {
+    return { emit: cache!.emit, cache, plannerRan: false };
+  }
+  const emit = await runPlanner();
+  return { emit, cache: { key, emit }, plannerRan: true };
 }
 
 /**

--- a/.sandcastle/dispatch.test.mts
+++ b/.sandcastle/dispatch.test.mts
@@ -14,10 +14,15 @@ import {
   issueFromBranch,
   pickImplementers,
   pickPrs,
+  planCacheKey,
+  resolvePlanEmit,
   shouldQueryBuckets,
+  shouldReusePlan,
   shouldRunPlanner,
   type BucketPr,
+  type EmittedIssue,
   type GhRunner,
+  type PlanCache,
   type ReadyForAgentIssue,
 } from "./dispatch.mts";
 
@@ -30,10 +35,15 @@ import {
  * logic while `main.mts` drives live sandboxes.
  */
 
-const issue = (number: number, labels: string[] = []): ReadyForAgentIssue => ({
+const issue = (
+  number: number,
+  labels: string[] = [],
+  updatedAt = `2026-01-01T00:00:0${number}Z`
+): ReadyForAgentIssue => ({
   number,
   title: `Issue #${number}`,
   labels,
+  updatedAt,
 });
 
 /** A recording GhRunner that optionally throws on the defensive label-create. */
@@ -488,6 +498,155 @@ describe("pickPrs", () => {
   });
 });
 
+// ---- #86 — Plan cache: skip the Planner while the ready-set is unchanged (ADR-0010) --
+
+/**
+ * #86 — the Plan cache (ADR-0010). The orchestrator caches the Planner's last
+ * emit list keyed by a content-hash of the RAW `ready-for-agent` issue set it
+ * reasons over (`hash(sorted [(number, updatedAt)])`). While that key is
+ * unchanged a Poll tick dispatches from the cached emit with zero Opus calls;
+ * the Planner is re-invoked only when the key moves. The pure key + the
+ * reuse-vs-replan predicate live here, mirroring `shouldRunPlanner` /
+ * `pickImplementers`; the cache value itself lives in `main.mts` beside
+ * `inflight`.
+ */
+describe("planCacheKey", () => {
+  it("produces a stable string for the same raw ready-for-agent set", () => {
+    const set = [issue(1), issue(2)];
+    expect(planCacheKey(set)).toBe(planCacheKey(set));
+    expect(typeof planCacheKey(set)).toBe("string");
+  });
+
+  it("is order-independent (gh list order must not move the key)", () => {
+    const a = [issue(1), issue(2), issue(3)];
+    const b = [issue(3), issue(1), issue(2)];
+    expect(planCacheKey(a)).toBe(planCacheKey(b));
+  });
+
+  it("changes when an issue is added to the set", () => {
+    const before = planCacheKey([issue(1), issue(2)]);
+    const after = planCacheKey([issue(1), issue(2), issue(3)]);
+    expect(after).not.toBe(before);
+  });
+
+  it("changes when an issue is removed from the set (e.g. a blocker merges out)", () => {
+    const before = planCacheKey([issue(1), issue(2), issue(3)]);
+    const after = planCacheKey([issue(2), issue(3)]);
+    expect(after).not.toBe(before);
+  });
+
+  it("changes when an issue's updatedAt changes (edit/comment/label bump)", () => {
+    const before = planCacheKey([issue(1, [], "2026-01-01T00:00:00Z"), issue(2)]);
+    const after = planCacheKey([issue(1, [], "2026-06-01T00:00:00Z"), issue(2)]);
+    expect(after).not.toBe(before);
+  });
+
+  it("is stable when only in-flight/PR state (not in the key) would differ", () => {
+    // Same numbers + updatedAt → same key, regardless of labels the key ignores.
+    const a = [issue(1, ["ready-for-agent"]), issue(2, ["ready-for-agent"])];
+    const b = [issue(1, ["ready-for-agent", "needs-triage"]), issue(2, [])];
+    expect(planCacheKey(a)).toBe(planCacheKey(b));
+  });
+});
+
+describe("shouldReusePlan", () => {
+  const emit: EmittedIssue[] = [{ number: 1, title: "A", branch: "sandcastle/issue-1" }];
+
+  it("re-plans when the cache is cold (null)", () => {
+    expect(shouldReusePlan("k", null)).toBe(false);
+  });
+
+  it("reuses the cached emit when the key matches", () => {
+    const cache: PlanCache = { key: "k", emit };
+    expect(shouldReusePlan("k", cache)).toBe(true);
+  });
+
+  it("re-plans when the key has moved (ready-set changed)", () => {
+    const cache: PlanCache = { key: "old", emit };
+    expect(shouldReusePlan("new", cache)).toBe(false);
+  });
+});
+
+describe("resolvePlanEmit", () => {
+  const emitted = (...ns: number[]): EmittedIssue[] =>
+    ns.map((n) => ({ number: n, title: `#${n}`, branch: `sandcastle/issue-${n}` }));
+
+  it("runs the Planner once across two ticks with an unchanged raw set", async () => {
+    const raw = [issue(1), issue(2)];
+    let calls = 0;
+    const runPlanner = async () => (calls++, emitted(1));
+
+    let cache: PlanCache = null;
+    const t1 = await resolvePlanEmit(raw, cache, runPlanner);
+    cache = t1.cache;
+    const t2 = await resolvePlanEmit(raw, cache, runPlanner);
+
+    expect(calls).toBe(1); // one Opus Planner Session, not two
+    expect(t1.plannerRan).toBe(true);
+    expect(t2.plannerRan).toBe(false);
+    expect(t2.emit).toEqual(t1.emit); // cache hit serves the same emit
+  });
+
+  it("re-plans when the raw set changes (a blocker merges out of the query)", async () => {
+    let calls = 0;
+    const runPlanner = async () => (calls++, emitted());
+
+    let cache: PlanCache = null;
+    const first = await resolvePlanEmit([issue(1), issue(2), issue(3)], cache, runPlanner);
+    cache = first.cache;
+    // #1 merged → closed → leaves the ready-for-agent query. Key flips → re-plan.
+    const second = await resolvePlanEmit([issue(2), issue(3)], cache, runPlanner);
+
+    expect(calls).toBe(2);
+    expect(second.plannerRan).toBe(true);
+  });
+
+  it("cache hit still dispatches: capped emit {A,D,E} + 1 slot → A, then D,E, no re-plan", async () => {
+    // The starvation guard (ADR-0010): a cache hit skips the LLM, NOT the
+    // dispatch — so a capped emit still drains on later ticks without re-planning.
+    let calls = 0;
+    const runPlanner = async () => (calls++, emitted(1, 4, 5)); // A, D, E
+    const raw = [issue(1), issue(4), issue(5)];
+    const inflight = createInflight();
+
+    let cache: PlanCache = null;
+
+    // Tick 1 — cold cache → plan; only 1 free slot caps the emit to A.
+    const t1 = await resolvePlanEmit(raw, cache, runPlanner);
+    cache = t1.cache;
+    const picked1 = pickImplementers(t1.emit, 1, inflight);
+    picked1.forEach((i) => inflight.add(i.number));
+    expect(picked1.map((i) => i.number)).toEqual([1]);
+
+    // Tick 2 — A still in-flight its whole Run; same raw set → cache hit (no
+    // Planner). Dispatch from cached emit skips in-flight A → D, E fill 2 slots.
+    const t2 = await resolvePlanEmit(raw, cache, runPlanner);
+    cache = t2.cache;
+    const picked2 = pickImplementers(t2.emit, 2, inflight);
+
+    expect(t2.plannerRan).toBe(false);
+    expect(picked2.map((i) => i.number)).toEqual([4, 5]);
+    expect(calls).toBe(1); // one plan served both ticks — no starvation, no Opus
+  });
+
+  it("keys off the RAW set passed in, not any post-filter actionable subset", async () => {
+    // Passing the full raw set keeps the cache valid across a blocker's Run; the
+    // caller must pass queryReadyForAgent's result, never `actionable`.
+    let calls = 0;
+    const runPlanner = async () => (calls++, emitted(1));
+    const raw = [issue(1), issue(2), issue(3)];
+
+    let cache: PlanCache = null;
+    const a = await resolvePlanEmit(raw, cache, runPlanner);
+    cache = a.cache;
+    // Same raw set on the next tick (even though actionable would have shrunk to
+    // {2,3} once #1 went in-flight) → cache hit, no second Planner call.
+    const b = await resolvePlanEmit(raw, cache, runPlanner);
+    expect(b.plannerRan).toBe(false);
+    expect(calls).toBe(1);
+  });
+});
+
 // ---- main.mts structural guards (read source, never import — it runs the loop) --
 
 const mainSource = readFileSync(new URL("./main.mts", import.meta.url), "utf8");
@@ -550,5 +709,35 @@ describe("main.mts — persistent shared-pool orchestrator (ADR-0006)", () => {
     // plan — `remaining` is the post-drain free count passed to shouldRunPlanner.
     expect(mainSource).toMatch(/remaining/);
     expect(mainSource).toMatch(/shouldRunPlanner\(actionable, remaining\)/);
+  });
+});
+
+describe("main.mts — Plan cache wiring (ADR-0010, #86)", () => {
+  it("fetches updatedAt for the ready-for-agent bucket (the key needs it)", () => {
+    expect(mainSource).toMatch(/number,title,labels,updatedAt/);
+  });
+
+  it("holds one in-memory Plan cache value beside the In-flight set", () => {
+    expect(mainSource).toMatch(/let planCache: PlanCache = null/);
+  });
+
+  it("resolves the implement-stage emit through the cache (resolvePlanEmit)", () => {
+    // The gate reuses the cached emit while the ready-set is unchanged; the cache
+    // value is threaded back in (`planCache = resolved.cache`).
+    expect(mainSource).toMatch(/resolvePlanEmit\(/);
+    expect(mainSource).toMatch(/planCache = resolved\.cache/);
+  });
+
+  it("keys the cache on the RAW query result, not the post-filter actionable set", () => {
+    // Load-bearing (ADR-0010): passing `readyForAgent` (pre-filter) keeps the
+    // cache honest when a blocker merges out; `actionable` would go stale.
+    expect(mainSource).toMatch(/resolvePlanEmit\(readyForAgent,/);
+    expect(mainSource).not.toMatch(/resolvePlanEmit\(actionable,/);
+  });
+
+  it("still runs the pure dispatch (pickImplementers) over the resolved emit", () => {
+    // A cache hit skips the LLM, never the dispatch — capped emits still drain.
+    expect(mainSource).toMatch(/resolved\.emit\.filter/);
+    expect(mainSource).toMatch(/pickImplementers\(dispatchable, remaining, inflight\)/);
   });
 });

--- a/.sandcastle/events.mts
+++ b/.sandcastle/events.mts
@@ -71,6 +71,13 @@ interface PlannerEmittedEvent extends BaseEvent {
   readonly count: number;
 }
 
+/** Plan cache hit (ADR-0010): the raw ready-for-agent set was unchanged, so the
+ *  cached emit list was reused and the Planner (Opus) was NOT called this tick. */
+interface PlanReusedEvent extends BaseEvent {
+  readonly type: "plan-reused";
+  readonly count: number;
+}
+
 /** No actionable ready-for-agent issues, or no free slot after merge+review. */
 interface PlannerSkippedEvent extends BaseEvent {
   readonly type: "planner-skipped";
@@ -124,6 +131,7 @@ export type OrchestratorEvent =
   | BucketsEvent
   | DispatchEvent
   | PlannerEmittedEvent
+  | PlanReusedEvent
   | PlannerSkippedEvent
   | PlannerNoPlanEvent
   | PlannerFailedEvent
@@ -158,6 +166,8 @@ export function formatEventProse(event: OrchestratorEvent): string | null {
       return `  → dispatching ${roleWord(event.role)} for PR #${event.pr} (issue #${event.issue}) → ${event.branch}`;
     case "planner-emitted":
       return `Planner emitted ${event.count} unblocked issue(s).`;
+    case "plan-reused":
+      return `Plan cache hit — reusing ${event.count} emitted issue(s), no Planner call this tick.`;
     case "planner-skipped":
       return "No actionable ready-for-agent issues, or no free slot after merge+review draining — skipping Planner this tick.";
     case "planner-no-plan":
@@ -256,6 +266,8 @@ export interface OrchestratorEvents {
   dispatchMerger(pr: number, issue: number, branch: string): void;
   /** The Planner emitted `count` unblocked issues. */
   plannerEmitted(count: number): void;
+  /** Plan cache hit — the cached emit (`count` issues) was reused, no Opus call. */
+  planReused(count: number): void;
   /** No actionable issues / no free slot — the Planner is skipped this tick. */
   plannerSkipped(): void;
   /** The Planner resolved but produced no `<plan>` tag. */
@@ -326,6 +338,7 @@ export function createEvents(opts: CreateEventsOptions = {}): OrchestratorEvents
     dispatchMerger: (pr, issue, branch) =>
       emit({ type: "dispatch", role: "merger", issue, branch, pr, title: null, ts: stamp() }),
     plannerEmitted: (count) => emit({ type: "planner-emitted", count, ts: stamp() }),
+    planReused: (count) => emit({ type: "plan-reused", count, ts: stamp() }),
     plannerSkipped: () => emit({ type: "planner-skipped", ts: stamp() }),
     plannerNoPlan: () => emit({ type: "planner-no-plan", ts: stamp() }),
     plannerFailed: (error) => emit({ type: "planner-failed", error, ts: stamp() }),

--- a/.sandcastle/events.test.mts
+++ b/.sandcastle/events.test.mts
@@ -98,6 +98,12 @@ describe("formatEventProse", () => {
     );
   });
 
+  it("reproduces the plan-reused (cache hit) line", () => {
+    expect(formatEventProse(evt({ type: "plan-reused", count: 3 }))).toBe(
+      "Plan cache hit — reusing 3 emitted issue(s), no Planner call this tick."
+    );
+  });
+
   it("reproduces the no-<plan> tag line", () => {
     expect(formatEventProse(evt({ type: "planner-no-plan" }))).toBe(
       "Planner did not produce a <plan> tag."
@@ -209,6 +215,7 @@ describe("formatEventProse", () => {
         title: "t",
       },
       { type: "planner-emitted", count: 0 },
+      { type: "plan-reused", count: 0 },
       { type: "planner-skipped" },
       { type: "planner-no-plan" },
       { type: "planner-failed", error: "x" },

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -14,9 +14,12 @@ import {
   pickPrs,
   POLL_INTERVAL_MS,
   POOL_SIZE,
+  resolvePlanEmit,
   shouldQueryBuckets,
   shouldRunPlanner,
   type BucketPr,
+  type EmittedIssue,
+  type PlanCache,
   type ReadyForAgentIssue,
 } from "./dispatch.mts";
 import {
@@ -150,17 +153,19 @@ async function queryReadyForAgent(): Promise<ReadyForAgentIssue[]> {
     "--limit",
     "200",
     "--json",
-    "number,title,labels",
+    "number,title,labels,updatedAt",
   ]);
   const rows = JSON.parse(out || "[]") as {
     number: number;
     title: string;
     labels: { name: string }[];
+    updatedAt: string;
   }[];
   return rows.map((r) => ({
     number: r.number,
     title: r.title,
     labels: r.labels.map((l) => l.name),
+    updatedAt: r.updatedAt,
   }));
 }
 
@@ -231,6 +236,13 @@ const events = createEvents();
 // so it is not re-dispatched; Reviewer/Merger give-up paths live in the prompts (#65).
 const pool = createPool(POOL_SIZE);
 const inflight = createInflight();
+
+// The Plan cache (ADR-0010): the Planner's last emit list keyed by a
+// content-hash of the raw `ready-for-agent` set. In-memory / non-durable (cold
+// after restart → one re-plan), living beside the In-flight set. While the key
+// is unchanged, the implement stage dispatches from `planCache.emit` with no
+// Opus Planner call; `resolvePlanEmit` re-invokes the Planner only on a miss.
+let planCache: PlanCache = null;
 
 /**
  * Dispatch one Implementer for an issue into the shared Pool. Occupies a slot
@@ -497,7 +509,7 @@ async function dispatchMerger(pr: {
  * itself (see plan-prompt.md); the orchestrator only invokes it when there is
  * actionable work to analyze. Returns `[]` if the Planner produced no plan.
  */
-async function runPlanner(): Promise<{ number: number; title: string; branch: string }[]> {
+async function runPlanner(): Promise<EmittedIssue[]> {
   const plannerRunId = generateRunId();
   const planLC = lifecycle("planner");
   planLC.start();
@@ -572,19 +584,29 @@ for (;;) {
     }
     remaining -= reviewers.length;
 
-    // 3) ready-for-agent — the Planner runs in its own Pool-exempt slot ONLY
-    // when actionable issues exist AND a slot remains after merge+review
-    // draining (don't spend Opus on a plan we can't dispatch). It re-plans
-    // every eligible tick (no caching); pickImplementers caps at `remaining`.
+    // 3) ready-for-agent — the implement stage runs ONLY when actionable issues
+    // exist AND a slot remains after merge+review draining (don't spend a slot
+    // on work we can't start). The Plan cache (ADR-0010) skips the Opus Planner
+    // while the RAW ready-for-agent set is unchanged: `resolvePlanEmit` keys on
+    // `readyForAgent` (the pre-filter query result, NOT `actionable` — else the
+    // cache goes stale when a blocker merges out), reuses the cached emit on a
+    // hit, and re-invokes the Planner only on a miss. Either way the pure
+    // dispatch below runs over the emit, so a capped emit still drains on later
+    // ticks (no starvation). `pickImplementers` caps at `remaining`.
     if (shouldRunPlanner(actionable, remaining)) {
       try {
-        const emitted = await runPlanner();
-        events.plannerEmitted(emitted.length);
+        const resolved = await resolvePlanEmit(readyForAgent, planCache, runPlanner);
+        planCache = resolved.cache;
+        if (resolved.plannerRan) {
+          events.plannerEmitted(resolved.emit.length);
+        } else {
+          events.planReused(resolved.emit.length);
+        }
 
         // The Planner re-queries gh, so it can emit an issue that just got a PR
         // this tick — drop those before dispatching. (In-flight dedupe + the
         // remaining-slot cap happen in pickImplementers.)
-        const dispatchable = emitted.filter((i) => !openPrIssues.has(i.number));
+        const dispatchable = resolved.emit.filter((i) => !openPrIssues.has(i.number));
         const toDispatch = pickImplementers(dispatchable, remaining, inflight);
 
         for (const issue of toDispatch) {


### PR DESCRIPTION
Implements **ADR-0010**. Closes #86.

The persistent orchestrator re-ran the Opus **Planner** on every eligible Poll tick even when it could only emit undispatchable issues (a blocker A stays `ready-for-agent` + open its whole Run, so the Planner just re-emits A, which is filtered out — pure wasted Opus every ~60s for A's entire implement→review→merge lifecycle). This adds a **Plan cache**: the orchestrator dispatches from the Planner's cached emit while the raw `ready-for-agent` set is unchanged, and re-invokes the Planner only when that set actually changes.

## Pure layer — `dispatch.mts`
Mirrors `shouldRunPlanner` / `pickImplementers`, unit-tested in `dispatch.test.mts`:
- **`ReadyForAgentIssue`** now carries `updatedAt`.
- **`planCacheKey(issues)`** — canonical sorted `[(number, updatedAt)]` content key. Order-independent; changes on add/remove/`updatedAt`; stable otherwise.
- **`shouldReusePlan(key, cache)`** — the reuse-vs-replan predicate.
- **`resolvePlanEmit(readyForAgent, cache, runPlanner)`** — injectable async gate (same pattern as `handleImplementerOutcome`) that runs the Planner **only on a cache miss**. A cache hit still runs the pure dispatch over the cached emit (no starvation) and never touches labels (misdispatch invariant preserved).

## Wiring — `main.mts`
- `queryReadyForAgent` fetches `number,title,labels,updatedAt`.
- One in-memory `planCache` beside `inflight` (non-durable — cold after restart → one re-plan, consistent with the In-flight set).
- The implement stage keys on the **raw** query result (not the post-filter `actionable`), so a blocker merging out of the query flips the key and forces a re-plan.

## Observability — `events.mts` + `cockpit-core.mts`
A `plan-reused` event makes a cache hit visible instead of looking like a Planner skip (prose + NDJSON renderers, Cockpit allowlist + log line).

## Acceptance criteria — all met
- [x] `queryReadyForAgent` fetches `updatedAt`; `ReadyForAgentIssue` carries it
- [x] `planCacheKey` hashes the raw set as sorted `[(number, updatedAt)]` — order-independent; changes on add/remove/`updatedAt`; stable otherwise
- [x] Pure reuse-vs-replan predicate, unit-tested
- [x] Two ticks / unchanged raw set → Planner runs **once**
- [x] Cache hit still dispatches: capped `{A,D,E}` + 1 slot → A on tick 1, D & E next tick, no intervening Planner call
- [x] Key computed from the raw query result, not `actionable`; a blocker merging flips the key
- [x] No labels stripped by the cache path; the Planner still receives the full set
- [x] Existing `dispatch.test.mts` cases pass; typecheck clean

## Testing
- **317/317 sandcastle tests pass**; targeted typecheck clean across all changed `.mts` modules.
- Built test-first (RED→GREEN per behavior). Four unrelated failures in `lib/og.test.ts` / `components/PostOgCard.test.tsx` are a pre-existing local-timezone artifact (fail identically on a clean tree; untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)