### PR TITLE
#92 Prefactor: single event-rendering seam for the orchestrator event stream

### DIFF
--- a/.sandcastle/cockpit-core.mts
+++ b/.sandcastle/cockpit-core.mts
@@ -7,19 +7,25 @@
  * - the **tab model** (`COCKPIT_TABS` + `cycleTab`) behind the tab-switch keybind,
  * - the **NDJSON stream** decode (`splitNdjsonChunk` + `parseEventLine`) that turns
  *   the supervised child's stdout chunks into typed orchestrator events,
- * - the **event log** (`formatEventLog` + `appendLogLine`) that renders those
- *   events as bounded, scrolling one-liners, and
+ * - the **event log** ring (`appendLogLine`) that bounds those rendered one-liners, and
  * - the **child-exit** classification (`describeChildExit`) that decides whether a
  *   child that went away was a clean Stop or a crash to surface.
  *
  * - the **supervisor** (`spawnOrchestrator`) that launches the orchestrator as a
  *   child process and threads its stdout/stderr through the decode above.
  *
- * The event *shape* is owned by `events.mts` (the contract the orchestrator emits
- * and the Cockpit consumes); this module only decodes and presents it.
+ * The event *shape* AND its rendering are owned by `events.mts` — the single
+ * event-rendering seam (`formatEventLog`, `eventSeverity`, `roleAbbr`, the
+ * `isKnownEventType` allow-list). This module only decodes the stream and folds
+ * it into view state; it renders no event strings of its own.
  */
 import { spawn, type ChildProcess } from "node:child_process";
-import type { OrchestratorEvent } from "./events.mts";
+import {
+  isKnownEventType,
+  roleAbbr,
+  type OrchestratorEvent,
+  type OrchestratorRole,
+} from "./events.mts";
 import type { PrunePlan } from "./prune-plan.mts";
 
 /** The Cockpit's tabbed modes, in cycle order (CONTEXT.md: Cockpit). */
@@ -71,24 +77,6 @@ export function routeCockpitInput(input: string, key: InputKey): CockpitInputAct
   return { kind: "delegate" };
 }
 
-/** Every `type` discriminator the orchestrator can emit — the allow-list
- *  `parseEventLine` checks so a stray non-event JSON line (or a future unknown
- *  type) is dropped rather than mis-rendered. */
-const KNOWN_EVENT_TYPES = new Set<OrchestratorEvent["type"]>([
-  "tick",
-  "pool-full",
-  "buckets",
-  "dispatch",
-  "planner-emitted",
-  "plan-reused",
-  "planner-skipped",
-  "planner-no-plan",
-  "planner-failed",
-  "noop-escalated",
-  "gh-error",
-  "session-resolved",
-]);
-
 /**
  * Decode one line of the child's NDJSON stdout into a typed
  * {@link OrchestratorEvent}, or `null` when the line is not a usable event.
@@ -99,6 +87,9 @@ const KNOWN_EVENT_TYPES = new Set<OrchestratorEvent["type"]>([
  * returns `null` for a blank line, non-JSON, non-object JSON, or a JSON object
  * whose `type` is not a known orchestrator event — the Cockpit simply skips
  * those rather than crashing or showing garbage.
+ *
+ * The allow-list is `isKnownEventType` from `events.mts`, derived from the event
+ * union — so it can never drift from the shipped events by hand.
  */
 export function parseEventLine(line: string): OrchestratorEvent | null {
   const trimmed = line.trim();
@@ -111,9 +102,7 @@ export function parseEventLine(line: string): OrchestratorEvent | null {
   }
   if (typeof parsed !== "object" || parsed === null) return null;
   const type = (parsed as { type?: unknown }).type;
-  if (typeof type !== "string" || !KNOWN_EVENT_TYPES.has(type as OrchestratorEvent["type"])) {
-    return null;
-  }
+  if (typeof type !== "string" || !isKnownEventType(type)) return null;
   return parsed as OrchestratorEvent;
 }
 
@@ -144,57 +133,6 @@ export function splitNdjsonChunk(buffer: string, chunk: string): ChunkSplit {
   const parts = combined.split("\n");
   const rest = parts.pop() ?? "";
   return { lines: parts, rest };
-}
-
-/**
- * Render one orchestrator event as a single compact line for the Live tab's
- * scrolling event log. Distinct from `formatEventProse` in `events.mts`: this is
- * a **total** formatter — every event produces exactly one glanceable line,
- * including a *successful* `session-resolved` (which prose deliberately renders
- * to nothing because the headless `lifecycle` markers cover it). The Cockpit's
- * job is the opposite of headless: surface every live resolution.
- *
- * No timestamp is included — the log line is the event's semantics only; the
- * React layer prefixes a wall-clock time from `event.ts`. Pure so the exact
- * strings are unit-testable in isolation.
- */
-export function formatEventLog(event: OrchestratorEvent): string {
-  switch (event.type) {
-    case "tick":
-      return `tick · ${event.free}/${event.poolSize} free · ${event.inflight} in-flight`;
-    case "dispatch":
-      return event.role === "implementer"
-        ? `▶ dispatch impl #${event.issue}: ${event.title}`
-        : `▶ dispatch ${roleAbbr(event.role)} PR #${event.pr} (#${event.issue})`;
-    case "session-resolved":
-      return event.status === "ok"
-        ? `✓ ${roleAbbr(event.role)} #${event.issue} resolved · ${event.commits} commits`
-        : `✗ ${roleAbbr(event.role)} #${event.issue} failed · ${event.error}`;
-    case "pool-full":
-      return "pool full · gh query skipped";
-    case "buckets":
-      return `buckets · merge ${event.merge} · review ${event.review} · agent ${event.agent} (${event.actionable} actionable)`;
-    case "planner-emitted":
-      return `planner emitted ${event.count} issue(s)`;
-    case "plan-reused":
-      return `plan cache hit · reused ${event.count} issue(s) · no planner call`;
-    case "planner-skipped":
-      return "planner skipped";
-    case "planner-no-plan":
-      return "planner produced no plan";
-    case "planner-failed":
-      return `⚠ planner failed · ${event.error}`;
-    case "noop-escalated":
-      return `⚠ #${event.issue} no commits · escalated to ready-for-human`;
-    case "gh-error":
-      return `⚠ gh ${event.args.join(" ")} failed · ${event.error}`;
-    default: {
-      // Exhaustiveness guard: adding a new OrchestratorEvent type without a log
-      // line here is a compile error, so the Live log can never silently omit one.
-      const unreachable: never = event;
-      return unreachable;
-    }
-  }
 }
 
 /**
@@ -346,7 +284,7 @@ export function spawnOrchestrator(config: SpawnConfig, handlers: OrchestratorHan
  *  Session resolves, ADR-0008). */
 export interface InFlightEntry {
   readonly issue: number;
-  readonly role: "implementer" | "reviewer" | "merger";
+  readonly role: OrchestratorRole;
   /** The PR under review/merge; null for an Implementer (no PR yet). */
   readonly pr: number | null;
   /** The issue title (Implementer dispatch only; null for Reviewer/Merger). */
@@ -425,19 +363,6 @@ export function formatInFlight(entry: InFlightEntry): string {
     return `impl #${entry.issue}${entry.title ? ` · ${entry.title}` : ""}`;
   }
   return `${roleAbbr(entry.role)} PR #${entry.pr} (#${entry.issue})`;
-}
-
-/** The compact role tag used in log lines: `impl` / `rev` / `merger`. Mirrors
- *  the labels the orchestrator's `lifecycle`/prose output already uses. */
-function roleAbbr(role: "implementer" | "reviewer" | "merger"): string {
-  switch (role) {
-    case "implementer":
-      return "impl";
-    case "reviewer":
-      return "rev";
-    case "merger":
-      return "merger";
-  }
 }
 
 /** Why the Maintenance tab may not apply the prune plan right now, or `null`

--- a/.sandcastle/cockpit-core.test.mts
+++ b/.sandcastle/cockpit-core.test.mts
@@ -6,7 +6,6 @@ import {
   cycleTab,
   describeChildExit,
   EMPTY_LIVE_VIEW,
-  formatEventLog,
   formatInFlight,
   formatPoolGauge,
   parseEventLine,
@@ -20,7 +19,7 @@ import {
   type InputKey,
   type OrchestratorHandlers,
 } from "./cockpit-core.mts";
-import type { OrchestratorEvent } from "./events.mts";
+import { formatEventLog, type OrchestratorEvent } from "./events.mts";
 import type { PrunePlan } from "./prune-plan.mts";
 
 /** A PrunePlan fixture; every bucket empty unless overridden. */

--- a/.sandcastle/cockpit.tsx
+++ b/.sandcastle/cockpit.tsx
@@ -65,7 +65,6 @@ import {
   cycleTab,
   describePruneApply,
   EMPTY_LIVE_VIEW,
-  formatEventLog,
   formatInFlight,
   formatPoolGauge,
   prunePlanTotal,
@@ -78,7 +77,7 @@ import {
   type PruneApplyPhase,
   type Supervisor,
 } from "./cockpit-core.mjs";
-import type { OrchestratorEvent } from "./events.mjs";
+import { formatEventLog, eventSeverity, type OrchestratorEvent } from "./events.mjs";
 import { planPrune, type PrunePlan, type PruneWorktree } from "./prune-plan.mjs";
 import { applyPrunePlan, discoverPruneState } from "./prune-driver.mjs";
 import {
@@ -135,18 +134,22 @@ function clock(ts: string): string {
   return Number.isNaN(d.getTime()) ? "--:--:--" : d.toLocaleTimeString("en-GB", { hour12: false });
 }
 
-/** Turn one parsed orchestrator event into a coloured log entry: failures red,
- *  soft warnings yellow, everything else default. The line text is the pure,
- *  tested `formatEventLog`; only the colour choice is presentational. */
+/** Map an event's severity to a log-line colour: failures red, soft warnings
+ *  yellow, everything else default. The classification lives in the event seam
+ *  (`eventSeverity`); this is only the presentational colour choice. */
+const SEVERITY_COLOR: Record<ReturnType<typeof eventSeverity>, string | undefined> = {
+  failure: "red",
+  warn: "yellow",
+  normal: undefined,
+};
+
+/** Turn one parsed orchestrator event into a coloured log entry. The line text
+ *  is the pure, tested `formatEventLog`; the colour is `eventSeverity` mapped
+ *  through {@link SEVERITY_COLOR}. */
 function eventEntry(ev: OrchestratorEvent): LogEntry {
-  const failure =
-    ev.type === "gh-error" ||
-    ev.type === "planner-failed" ||
-    (ev.type === "session-resolved" && ev.status === "failed");
-  const warn = ev.type === "noop-escalated" || ev.type === "planner-no-plan";
   return {
     text: `${clock(ev.ts)}  ${formatEventLog(ev)}`,
-    color: failure ? "red" : warn ? "yellow" : undefined,
+    color: SEVERITY_COLOR[eventSeverity(ev)],
   };
 }
 

--- a/.sandcastle/events.mts
+++ b/.sandcastle/events.mts
@@ -3,16 +3,25 @@
  *
  * This is the seam extracted from `main.mts`'s ad-hoc `console.log`s (ADR-0008):
  * every orchestrator progress moment flows through ONE typed event emitter as a
- * discriminated union, and TWO renderers hang off that single source:
+ * discriminated union. This module is also the **single event-rendering seam**:
+ * every surface's view of an event is defined here, once, so adding a new event
+ * type is a one-place, compile-error-driven change (issue #92). The views:
  *
- * - **prose renderer** (default, headless `pnpm sandcastle`) — reproduces today's
- *   exact human-readable lines, routing error-shaped events to stderr and the
- *   rest to stdout, so output is byte-for-byte unchanged.
- * - **NDJSON renderer** (`SANDCASTLE_EVENT_FORMAT=ndjson`) — emits the same events
- *   as one JSON object per line on stdout, for a supervising Cockpit to parse.
+ * - **prose renderer** (`formatEventProse` + `eventStream`; default, headless
+ *   `pnpm sandcastle`) — reproduces today's exact human-readable lines, routing
+ *   error-shaped events to stderr and the rest to stdout, byte-for-byte unchanged.
+ * - **NDJSON renderer** (`formatEventNdjson`, `SANDCASTLE_EVENT_FORMAT=ndjson`) —
+ *   emits the same events as one JSON object per line for a supervising Cockpit.
+ * - **Cockpit log renderer** (`formatEventLog` + `eventSeverity`) — one compact,
+ *   coloured line per event for the Live tab's scrolling log.
  *
- * One event definition, two views. The orchestrator loop is untouched — this is
- * an output seam only (no behavioural change to dispatch/pool logic).
+ * All three share one role→string mapping ({@link ROLE_LABELS}), and the Cockpit's
+ * decode allow-list ({@link EVENT_TYPES}) is derived from the event union rather
+ * than hand-maintained. Every per-variant rendering is exhaustive over the union,
+ * so a new event type without a rendering fails to type-check in this one module.
+ *
+ * The orchestrator loop is untouched — this is an output seam only (no
+ * behavioural change to dispatch/pool logic).
  *
  * Scope note: the per-agent stream (`observe`/`lifecycle` in `observability.mts`)
  * is a separate, already-structured sub-feed (toolCall lines + lifecycle markers)
@@ -24,6 +33,10 @@
  */
 /** Renderer mode for the event stream. */
 export type EventFormat = "prose" | "ndjson";
+
+/** The three pooled agent roles a Session can run as. The single role vocabulary
+ *  every renderer speaks (see {@link ROLE_LABELS}). */
+export type OrchestratorRole = "implementer" | "reviewer" | "merger";
 
 /** Shared fields carried by every event. The NDJSON renderer keeps `ts`. */
 interface BaseEvent {
@@ -58,7 +71,7 @@ interface BucketsEvent extends BaseEvent {
  *  no fetched title). */
 interface DispatchEvent extends BaseEvent {
   readonly type: "dispatch";
-  readonly role: "implementer" | "reviewer" | "merger";
+  readonly role: OrchestratorRole;
   readonly issue: number;
   readonly branch: string;
   readonly pr: number | null;
@@ -113,7 +126,7 @@ interface GhErrorEvent extends BaseEvent {
  *  case (a successful resolution has no orchestrator prose line). */
 interface SessionResolvedEvent extends BaseEvent {
   readonly type: "session-resolved";
-  readonly role: "implementer" | "reviewer" | "merger";
+  readonly role: OrchestratorRole;
   readonly issue: number;
   readonly branch: string;
   readonly status: "ok" | "failed";
@@ -184,24 +197,35 @@ export function formatEventProse(event: OrchestratorEvent): string | null {
   }
 }
 
-/** The capitalized role word for the dispatch line (`Reviewer`/`Merger`). */
-function roleWord(role: "reviewer" | "merger"): string {
-  return role === "reviewer" ? "Reviewer" : "Merger";
+/**
+ * The single role→string mapping every renderer speaks — the one authoritative
+ * source for role wording across the headless prose lines, the Cockpit event
+ * log, and the in-flight list. `word` is the capitalized long form (prose
+ * dispatch: `Reviewer`); `abbr` is the compact tag (log / in-flight: `rev`).
+ */
+const ROLE_LABELS: Record<OrchestratorRole, { readonly word: string; readonly abbr: string }> = {
+  implementer: { word: "Implementer", abbr: "impl" },
+  reviewer: { word: "Reviewer", abbr: "rev" },
+  merger: { word: "Merger", abbr: "merger" },
+};
+
+/** The capitalized role word for a dispatch line (`Implementer`/`Reviewer`/`Merger`). */
+export function roleWord(role: OrchestratorRole): string {
+  return ROLE_LABELS[role].word;
+}
+
+/** The compact role tag used in log / in-flight lines: `impl` / `rev` / `merger`.
+ *  Mirrors the labels the orchestrator's `lifecycle`/prose output already uses. */
+export function roleAbbr(role: OrchestratorRole): string {
+  return ROLE_LABELS[role].abbr;
 }
 
 /** The role prefix on a failed-resolution line. The Implementer has none (just
  *  `#N`), while Reviewer/Merger read `rev #N`/`merger #N` — preserving today's
- *  asymmetry exactly. Returns the role word + trailing space (or empty), so the
+ *  asymmetry exactly. Returns the role tag + trailing space (or empty), so the
  *  caller always appends `#<issue>`. */
-function roleFailedPrefix(role: "implementer" | "reviewer" | "merger"): string {
-  switch (role) {
-    case "reviewer":
-      return "rev ";
-    case "merger":
-      return "merger ";
-    case "implementer":
-      return ""; // `#${issue}` with no role word
-  }
+function roleFailedPrefix(role: OrchestratorRole): string {
+  return role === "implementer" ? "" : `${roleAbbr(role)} `;
 }
 
 /**
@@ -222,6 +246,129 @@ export function eventStream(event: OrchestratorEvent): EventStream {
     default:
       return "stdout";
   }
+}
+
+/**
+ * Render one orchestrator event as a single compact line for the Cockpit Live
+ * tab's scrolling event log. Distinct from {@link formatEventProse}: this is a
+ * **total** formatter — every event produces exactly one glanceable line,
+ * including a *successful* `session-resolved` (which prose deliberately renders
+ * to nothing because the headless `lifecycle` markers cover it). The Cockpit's
+ * job is the opposite of headless: surface every live resolution.
+ *
+ * No timestamp is included — the log line is the event's semantics only; the
+ * React layer prefixes a wall-clock time from `event.ts`. Pure so the exact
+ * strings are unit-testable in isolation. Exhaustive over the union, so a new
+ * event type without a log line is a compile error, not a silently-omitted one.
+ */
+export function formatEventLog(event: OrchestratorEvent): string {
+  switch (event.type) {
+    case "tick":
+      return `tick · ${event.free}/${event.poolSize} free · ${event.inflight} in-flight`;
+    case "dispatch":
+      return event.role === "implementer"
+        ? `▶ dispatch impl #${event.issue}: ${event.title}`
+        : `▶ dispatch ${roleAbbr(event.role)} PR #${event.pr} (#${event.issue})`;
+    case "session-resolved":
+      return event.status === "ok"
+        ? `✓ ${roleAbbr(event.role)} #${event.issue} resolved · ${event.commits} commits`
+        : `✗ ${roleAbbr(event.role)} #${event.issue} failed · ${event.error}`;
+    case "pool-full":
+      return "pool full · gh query skipped";
+    case "buckets":
+      return `buckets · merge ${event.merge} · review ${event.review} · agent ${event.agent} (${event.actionable} actionable)`;
+    case "planner-emitted":
+      return `planner emitted ${event.count} issue(s)`;
+    case "plan-reused":
+      return `plan cache hit · reused ${event.count} issue(s) · no planner call`;
+    case "planner-skipped":
+      return "planner skipped";
+    case "planner-no-plan":
+      return "planner produced no plan";
+    case "planner-failed":
+      return `⚠ planner failed · ${event.error}`;
+    case "noop-escalated":
+      return `⚠ #${event.issue} no commits · escalated to ready-for-human`;
+    case "gh-error":
+      return `⚠ gh ${event.args.join(" ")} failed · ${event.error}`;
+    default: {
+      // Exhaustiveness guard: adding a new OrchestratorEvent type without a log
+      // line here is a compile error, so the Live log can never silently omit one.
+      const unreachable: never = event;
+      return unreachable;
+    }
+  }
+}
+
+/** How prominent a log line is: a hard `failure`, a soft `warn`, or `normal`.
+ *  The Cockpit maps this to a colour; the classification lives here so it stays
+ *  in lock-step with the other renderers in the one seam. */
+export type EventSeverity = "failure" | "warn" | "normal";
+
+/**
+ * Classify an event's severity for the Cockpit log's colour (failures red, soft
+ * escalations yellow, everything else default). Exhaustive over the union so a
+ * new event type must be given a severity here — one place, compile-enforced.
+ */
+export function eventSeverity(event: OrchestratorEvent): EventSeverity {
+  switch (event.type) {
+    case "gh-error":
+    case "planner-failed":
+      return "failure";
+    case "session-resolved":
+      return event.status === "failed" ? "failure" : "normal";
+    case "noop-escalated":
+    case "planner-no-plan":
+      return "warn";
+    case "tick":
+    case "pool-full":
+    case "buckets":
+    case "dispatch":
+    case "planner-emitted":
+    case "plan-reused":
+    case "planner-skipped":
+      return "normal";
+    default: {
+      const unreachable: never = event;
+      return unreachable;
+    }
+  }
+}
+
+/**
+ * The exhaustive tag map — every `OrchestratorEvent` variant MUST appear as a
+ * key, or this literal fails to type-check (a missing key is a compile error).
+ * This is what makes the Cockpit's decode allow-list ({@link EVENT_TYPES}) a
+ * projection of the union rather than a hand-maintained parallel list that can
+ * silently drift when a new event type is added.
+ */
+const EVENT_TYPE_TAGS: Record<OrchestratorEvent["type"], true> = {
+  tick: true,
+  "pool-full": true,
+  buckets: true,
+  dispatch: true,
+  "planner-emitted": true,
+  "plan-reused": true,
+  "planner-skipped": true,
+  "planner-no-plan": true,
+  "planner-failed": true,
+  "noop-escalated": true,
+  "gh-error": true,
+  "session-resolved": true,
+};
+
+/** Every `type` discriminator the orchestrator can emit, derived from the union
+ *  via {@link EVENT_TYPE_TAGS}. The Cockpit's decode path checks membership here
+ *  so a stray non-event JSON line (or a future unknown type) is dropped rather
+ *  than mis-rendered. */
+export const EVENT_TYPES: ReadonlySet<OrchestratorEvent["type"]> = new Set(
+  Object.keys(EVENT_TYPE_TAGS) as OrchestratorEvent["type"][]
+);
+
+/** Narrowing guard: is `type` a known orchestrator event discriminator? Used by
+ *  the Cockpit's `parseEventLine` to accept only union members. */
+export function isKnownEventType(type: string): type is OrchestratorEvent["type"] {
+  return (EVENT_TYPES as ReadonlySet<string>).has(type);
 }
 
 /**
@@ -276,7 +423,7 @@ export interface OrchestratorEvents {
   plannerFailed(error: string): void;
   /** A dispatched Session resolved (ok = `commits`; failed = `error`). */
   sessionResolved(args: {
-    role: "implementer" | "reviewer" | "merger";
+    role: OrchestratorRole;
     issue: number;
     branch: string;
     status: "ok" | "failed";

--- a/.sandcastle/events.test.mts
+++ b/.sandcastle/events.test.mts
@@ -2,9 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   createEvents,
+  EVENT_TYPES,
+  eventSeverity,
   eventStream,
   formatEventNdjson,
   formatEventProse,
+  isKnownEventType,
   resolveEventFormat,
   type OrchestratorEvent,
 } from "./events.mts";
@@ -486,5 +489,83 @@ describe("createEvents", () => {
     const b = JSON.parse(out.mock.calls[1][0] as string) as { ts: string };
     expect(a.ts).toBe("2026-07-04T10:00:00.000Z");
     expect(b.ts).toBe("2026-07-04T11:00:00.000Z");
+  });
+});
+
+// ── EVENT_TYPES / isKnownEventType: the decode allow-list, derived from the union ─
+
+describe("EVENT_TYPES / isKnownEventType", () => {
+  /** The canonical roster of every OrchestratorEvent tag. This test's job is to
+   *  catch divergence between the shipped allow-list and the union: a variant
+   *  added to the union (and thus to the exhaustive tag map) but forgotten here
+   *  fails the size assertion. */
+  const ALL_TYPES: OrchestratorEvent["type"][] = [
+    "tick",
+    "pool-full",
+    "buckets",
+    "dispatch",
+    "planner-emitted",
+    "plan-reused",
+    "planner-skipped",
+    "planner-no-plan",
+    "planner-failed",
+    "noop-escalated",
+    "gh-error",
+    "session-resolved",
+  ];
+
+  it("contains exactly every orchestrator event type, no more, no fewer", () => {
+    expect([...EVENT_TYPES].sort()).toEqual([...ALL_TYPES].sort());
+  });
+
+  it("recognizes every event type and rejects unknown ones", () => {
+    for (const type of ALL_TYPES) expect(isKnownEventType(type)).toBe(true);
+    expect(isKnownEventType("mystery")).toBe(false);
+    expect(isKnownEventType("")).toBe(false);
+  });
+});
+
+// ── eventSeverity: failure | warn | normal (drives the Cockpit log colour) ────
+
+describe("eventSeverity", () => {
+  it("classifies failures as failure", () => {
+    expect(eventSeverity(evt({ type: "gh-error", args: ["a"], error: "x" }))).toBe("failure");
+    expect(eventSeverity(evt({ type: "planner-failed", error: "x" }))).toBe("failure");
+    expect(
+      eventSeverity(
+        evt({
+          type: "session-resolved",
+          role: "reviewer",
+          issue: 1,
+          branch: "b",
+          status: "failed",
+          commits: 0,
+          error: "x",
+        })
+      )
+    ).toBe("failure");
+  });
+
+  it("classifies soft escalations as warn", () => {
+    expect(eventSeverity(evt({ type: "noop-escalated", issue: 1 }))).toBe("warn");
+    expect(eventSeverity(evt({ type: "planner-no-plan" }))).toBe("warn");
+  });
+
+  it("classifies progress events (incl. a successful resolution) as normal", () => {
+    expect(eventSeverity(evt({ type: "tick", free: 1, poolSize: 10, inflight: 0 }))).toBe("normal");
+    expect(eventSeverity(evt({ type: "planner-emitted", count: 1 }))).toBe("normal");
+    expect(
+      eventSeverity(
+        evt({
+          type: "session-resolved",
+          role: "implementer",
+          issue: 1,
+          branch: "b",
+          status: "ok",
+          commits: 2,
+          error: null,
+        })
+      )
+    ).toBe("normal");
   });
 });


### PR DESCRIPTION
Closes #92.

## What & why

Prefactor for the ADR-0011 Outcome work. Adding a new orchestrator event type used to mean touching three independent renderers — the headless prose formatter, the Cockpit event-log formatter, and the Cockpit's own colour renderer — each with its own role→string mapping, plus a hand-maintained allow-list of known event types in the Cockpit decode path that silently dropped anything it didn't recognize.

This consolidates everything into **one event-rendering seam** in `.sandcastle/events.mts`.

## Changes

- **One role→string mapping** — `ROLE_LABELS` (`{word, abbr}` per role) is the single source; `roleWord` / `roleAbbr` / `roleFailedPrefix` all derive from it. Adds the shared `OrchestratorRole` type, used by the union, the emitter, and `InFlightEntry`.
- **All rendering co-located in `events.mts`** — moved `formatEventLog` in from `cockpit-core.mts`, and extracted the Cockpit's colour choice into an exhaustive `eventSeverity(event): "failure" | "warn" | "normal"`. `cockpit.tsx`'s `eventEntry` now maps severity → colour via `SEVERITY_COLOR`.
- **Allow-list derived from the union** — replaced the hand-maintained `KNOWN_EVENT_TYPES` set with an exhaustive `Record<OrchestratorEvent["type"], true>` → `EVENT_TYPES` + `isKnownEventType`, consumed by `parseEventLine`. A missing variant is a compile error, not silent drift.

Prose, log, and severity are now three exhaustive switches in one module, so a new `OrchestratorEvent` type is a one-place, compile-error-driven change.

## Behaviour

Unchanged. Headless prose output is byte-for-byte identical (the pinned `events.test.mts` assertions are untouched and pass), and the Cockpit event-log rendering is preserved.

## Verification

- `pnpm typecheck` green; all **322 `.sandcastle` tests** green.
- Added tests (TDD red→green): `EVENT_TYPES`/`isKnownEventType` completeness and `eventSeverity` classification.
- Empirically confirmed the guarantee: injecting a throwaway `OrchestratorEvent` variant produces a **4-way compile error** in the seam (prose return-type, `formatEventLog` guard, `eventSeverity` guard, and the `EVENT_TYPE_TAGS` `Record`).

## Follow-ups filed

- #103 — `.sandcastle/` is not covered by any enforced typecheck (the exhaustiveness guarantee is structural-only until a TS upgrade wires it into an enforced command).
- #104 — pre-existing timezone-dependent OG-date test failures (unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)