### PR TITLE
#94 Link Transcripts on failed Manifest entries (best-effort)

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -29,6 +29,7 @@ import {
   generateRunId,
   lifecycle,
   observe,
+  resolveFailedSessionFile,
   sessionsDir,
   type RunLike,
 } from "./observability.mts";
@@ -96,6 +97,10 @@ async function recordedRun<R extends RunLike>(args: {
     );
     return result;
   } catch (error) {
+    // Best-effort: link the session JSONL captured before the crash so the
+    // failure is viewable in the Session browser / render CLI (issue #94).
+    const endedAt = new Date();
+    const session = await resolveFailedSessionFile({ startedAt, endedAt });
     await appendManifestLine(
       buildFailedManifestEntry({
         runId: args.runId,
@@ -103,8 +108,9 @@ async function recordedRun<R extends RunLike>(args: {
         issue: args.issue,
         branch: args.branch,
         error,
+        session,
         startedAt,
-        endedAt: new Date(),
+        endedAt,
       })
     );
     throw error;

--- a/.sandcastle/observability.mts
+++ b/.sandcastle/observability.mts
@@ -33,10 +33,13 @@
  * usage (see docs/adr/0001-relocate-and-source-transcripts-from-session-jsonl.md).
  * Entries are appended at run resolution (never batched) so a crashed or
  * Ctrl-C'd Run still leaves a complete record; a rejected `run()` still gets a
- * best-effort `status: "failed"` entry with the error and timing, without
- * guessing a transcript link.
+ * best-effort `status: "failed"` entry with the error and timing, and — when a
+ * session JSONL was captured before the crash — a best-effort Transcript link
+ * resolved from the sessions dir (issue #94), so the failures you most need to
+ * audit are viewable in the Session browser and render CLI instead of showing
+ * "not available locally".
  */
-import { appendFile, mkdir } from "node:fs/promises";
+import { appendFile, mkdir, readdir, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type {
   AgentStreamEvent,
@@ -324,22 +327,36 @@ export function buildManifestEntry(args: ManifestEntryArgs & { result: RunLike }
 }
 
 /**
+ * A resolved Transcript link for a failed run: the captured session JSONL and
+ * (best-effort) the session id parsed from its filename. `usage` and `commits`
+ * remain unknown on the failure path, so they are not part of this slice.
+ */
+export interface ResolvedSession {
+  readonly sessionId: string | null;
+  readonly sessionFile: string;
+}
+
+/**
  * Build a best-effort manifest entry for a rejected agent run. The generic
- * `run()` failure carries no `RunResult`, so `sessionId` / `sessionFile` /
- * `commits` / `usage` are deliberately left null/0 — no transcript link is
- * guessed (sessionId is unavailable, and mtime-matching is unreliable under
- * parallelism). The error is stringified for the record.
+ * `run()` failure carries no `RunResult`, so `commits` / `usage` are left 0/null.
+ *
+ * When `session` is supplied (resolved via {@link resolveFailedSessionFile}) its
+ * `sessionFile` / `sessionId` are recorded so the failure's Transcript — the
+ * session JSONL captured before the crash — is viewable in the Session browser
+ * and render CLI. When it is absent (nothing captured), both stay null and the
+ * browser renders the existing "not available locally" note. The error is
+ * stringified for the record. Pure and env-free so the field set is unit-testable.
  */
 export function buildFailedManifestEntry(
-  args: ManifestEntryArgs & { error: unknown }
+  args: ManifestEntryArgs & { error: unknown; session?: ResolvedSession | null }
 ): ManifestEntry {
   return {
     runId: args.runId,
     phase: args.phase,
     issue: args.issue ?? null,
     branch: args.branch ?? null,
-    sessionId: null,
-    sessionFile: null,
+    sessionId: args.session?.sessionId ?? null,
+    sessionFile: args.session?.sessionFile ?? null,
     commits: 0,
     usage: null,
     startedAt: args.startedAt.toISOString(),
@@ -347,6 +364,105 @@ export function buildFailedManifestEntry(
     status: "failed",
     error: errorMessage(args.error),
   };
+}
+
+// ---- Failed-run Transcript resolution (issue #94) -------------------------
+
+/** A captured session JSONL candidate: its absolute path and mtime in ms. */
+export interface SessionCandidate {
+  readonly file: string;
+  readonly mtimeMs: number;
+}
+
+/** The half-open run window a failed session's JSONL must have been written in. */
+export interface RunWindow {
+  readonly startedAt: Date;
+  readonly endedAt: Date;
+}
+
+/**
+ * Pick the session JSONL captured by a now-failed `run()`, best-effort: the
+ * newest candidate whose mtime falls within the run's `[startedAt, endedAt]`
+ * window. The window is load-bearing — it excludes JSONL left by *earlier*
+ * completed runs (mtime < startedAt), so a run that captured nothing resolves to
+ * `null` (keeping the "not available" behavior) instead of mislinking a prior
+ * run's Transcript. Under parallelism several sessions may share the window;
+ * newest-wins is the documented heuristic and ties resolve to input order.
+ *
+ * Pure and fs-free so the selection rule is unit-testable in isolation.
+ */
+export function pickFailedSessionFile(
+  candidates: readonly SessionCandidate[],
+  window: RunWindow
+): string | null {
+  const startMs = window.startedAt.getTime();
+  const endMs = window.endedAt.getTime();
+  let best: SessionCandidate | null = null;
+  for (const c of candidates) {
+    if (c.mtimeMs < startMs || c.mtimeMs > endMs) continue;
+    if (best === null || c.mtimeMs > best.mtimeMs) best = c;
+  }
+  return best ? best.file : null;
+}
+
+/**
+ * Parse the pi session id from a `<stamp>_<sessionId>.jsonl` filename, or `null`
+ * when the name has no `_<id>.jsonl` suffix. Pure. The id is a convenience for
+ * the record — resolution/render locate the Transcript by the `sessionFile` path
+ * directly, so a null here never breaks viewing.
+ */
+export function sessionIdFromFile(file: string): string | null {
+  const base = file.split(/[/\\]/).pop() ?? file;
+  const m = base.match(/_([^_]+)\.jsonl$/);
+  return m ? m[1] : null;
+}
+
+/** Recursively collect every `*.jsonl` under `dir` with its mtime. Never throws. */
+async function collectSessionCandidates(dir: string): Promise<SessionCandidate[]> {
+  const out: SessionCandidate[] = [];
+  const stack = [dir];
+  while (stack.length) {
+    const current = stack.pop()!;
+    let names: string[];
+    try {
+      names = await readdir(current);
+    } catch {
+      continue; // unreadable / missing dir — skip
+    }
+    for (const name of names) {
+      const full = join(current, name);
+      let s;
+      try {
+        s = await stat(full);
+      } catch {
+        continue;
+      }
+      if (s.isDirectory()) stack.push(full);
+      else if (s.isFile() && name.endsWith(".jsonl")) out.push({ file: full, mtimeMs: s.mtimeMs });
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve the Transcript link for a failed run best-effort: scan `baseDir` (the
+ * sessions dir, laid out `<baseDir>/--<encoded-cwd>--/<stamp>_<id>.jsonl` per
+ * ADR 0001) for session JSONL and {@link pickFailedSessionFile} the newest one
+ * written during the run window. Returns `null` when nothing was captured in the
+ * window. Never throws — observability must not break the run — so any fs error
+ * degrades to `null` (the caller records a null link, unchanged from before).
+ */
+export async function resolveFailedSessionFile(
+  window: RunWindow,
+  baseDir: string = sessionsDir
+): Promise<ResolvedSession | null> {
+  try {
+    const file = pickFailedSessionFile(await collectSessionCandidates(baseDir), window);
+    return file ? { sessionFile: file, sessionId: sessionIdFromFile(file) } : null;
+  } catch (err) {
+    console.error(`[manifest] failed to resolve transcript for failed run: ${errorMessage(err)}`);
+    return null;
+  }
 }
 
 /**

--- a/.sandcastle/observability.test.mts
+++ b/.sandcastle/observability.test.mts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -18,8 +18,12 @@ import {
   logPath,
   manifestPath,
   observe,
+  pickFailedSessionFile,
+  resolveFailedSessionFile,
+  sessionIdFromFile,
   sessionsDir,
   type RunLike,
+  type SessionCandidate,
 } from "./observability.mts";
 
 const toolCall = (
@@ -410,6 +414,141 @@ describe("buildFailedManifestEntry", () => {
     });
     expect(entry.error).toBe("oops");
     expect(entry.status).toBe("failed");
+  });
+
+  it("records a best-effort Transcript link when a captured session is resolved", () => {
+    const entry = buildFailedManifestEntry({
+      runId: "run-issue-94",
+      phase: "impl",
+      error: new Error("boom"),
+      session: {
+        sessionId: "sess-x",
+        sessionFile: "/repo/.sandcastle/sessions/--r--/9_sess-x.jsonl",
+      },
+      startedAt: new Date("2026-06-28T12:00:00.000Z"),
+      endedAt: new Date("2026-06-28T12:01:00.000Z"),
+    });
+    expect(entry.sessionId).toBe("sess-x");
+    expect(entry.sessionFile).toBe("/repo/.sandcastle/sessions/--r--/9_sess-x.jsonl");
+    // The rest of the failure fields are unchanged.
+    expect(entry.commits).toBe(0);
+    expect(entry.usage).toBeNull();
+    expect(entry.status).toBe("failed");
+  });
+
+  it("leaves the link null when no session was resolved (null / undefined session)", () => {
+    const base = {
+      runId: "r",
+      phase: "impl",
+      error: "x",
+      startedAt: new Date(0),
+      endedAt: new Date(0),
+    };
+    for (const session of [null, undefined]) {
+      const entry = buildFailedManifestEntry({ ...base, session });
+      expect(entry.sessionId).toBeNull();
+      expect(entry.sessionFile).toBeNull();
+    }
+  });
+});
+
+describe("pickFailedSessionFile", () => {
+  const window = {
+    startedAt: new Date("2026-06-28T12:00:00.000Z"),
+    endedAt: new Date("2026-06-28T12:05:00.000Z"),
+  };
+  const at = (iso: string): number => new Date(iso).getTime();
+  const cand = (file: string, iso: string): SessionCandidate => ({ file, mtimeMs: at(iso) });
+
+  it("picks the newest candidate written within the run window", () => {
+    const candidates = [
+      cand("/s/mid.jsonl", "2026-06-28T12:01:00.000Z"),
+      cand("/s/new.jsonl", "2026-06-28T12:04:00.000Z"),
+      cand("/s/early.jsonl", "2026-06-28T12:00:30.000Z"),
+    ];
+    expect(pickFailedSessionFile(candidates, window)).toBe("/s/new.jsonl");
+  });
+
+  it("excludes leftovers from earlier runs (mtime before startedAt)", () => {
+    // A run that captured nothing must resolve to null, not mislink an old Transcript.
+    const candidates = [cand("/s/old.jsonl", "2026-06-28T11:00:00.000Z")];
+    expect(pickFailedSessionFile(candidates, window)).toBeNull();
+  });
+
+  it("excludes sessions written after the run ended", () => {
+    const candidates = [cand("/s/future.jsonl", "2026-06-28T12:06:00.000Z")];
+    expect(pickFailedSessionFile(candidates, window)).toBeNull();
+  });
+
+  it("includes candidates on the window boundaries", () => {
+    const candidates = [
+      cand("/s/start.jsonl", "2026-06-28T12:00:00.000Z"),
+      cand("/s/end.jsonl", "2026-06-28T12:05:00.000Z"),
+    ];
+    expect(pickFailedSessionFile(candidates, window)).toBe("/s/end.jsonl");
+  });
+
+  it("returns null for no candidates", () => {
+    expect(pickFailedSessionFile([], window)).toBeNull();
+  });
+});
+
+describe("sessionIdFromFile", () => {
+  it("parses the id from a <stamp>_<sessionId>.jsonl filename", () => {
+    expect(sessionIdFromFile("2026-06-28T01-00-00-000Z_sess-abc.jsonl")).toBe("sess-abc");
+  });
+
+  it("parses from a full path with directory separators", () => {
+    expect(sessionIdFromFile("/repo/.sandcastle/sessions/--r--/9_sess-x.jsonl")).toBe("sess-x");
+  });
+
+  it("returns null when there is no _<id>.jsonl suffix", () => {
+    expect(sessionIdFromFile("/s/noid.jsonl")).toBeNull();
+    expect(sessionIdFromFile("/s/notjsonl_sess-x.txt")).toBeNull();
+  });
+});
+
+describe("resolveFailedSessionFile", () => {
+  let dir: string;
+  const window = {
+    startedAt: new Date("2026-06-28T12:00:00.000Z"),
+    endedAt: new Date("2026-06-28T12:05:00.000Z"),
+  };
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+    dir = "";
+  });
+
+  it("resolves the newest in-window JSONL under the encoded-cwd subdir, with its parsed id", async () => {
+    dir = await mkdtemp(join(tmpdir(), "failed-session-"));
+    const nested = join(dir, "--repo--");
+    await mkdir(nested, { recursive: true });
+    const older = join(nested, "2026-06-28T12-01-00-000Z_sess-old.jsonl");
+    const newer = join(nested, "2026-06-28T12-04-00-000Z_sess-new.jsonl");
+    await writeFile(older, "{}\n", "utf8");
+    await writeFile(newer, "{}\n", "utf8");
+    await utimes(older, new Date("2026-06-28T12:01:00.000Z"), new Date("2026-06-28T12:01:00.000Z"));
+    await utimes(newer, new Date("2026-06-28T12:04:00.000Z"), new Date("2026-06-28T12:04:00.000Z"));
+
+    expect(await resolveFailedSessionFile(window, dir)).toEqual({
+      sessionFile: newer,
+      sessionId: "sess-new",
+    });
+  });
+
+  it("returns null when the only JSONL predates the window (nothing captured this run)", async () => {
+    dir = await mkdtemp(join(tmpdir(), "failed-session-"));
+    const file = join(dir, "--repo--", "2026-06-28T11-00-00-000Z_sess-old.jsonl");
+    await mkdir(join(dir, "--repo--"), { recursive: true });
+    await writeFile(file, "{}\n", "utf8");
+    await utimes(file, new Date("2026-06-28T11:00:00.000Z"), new Date("2026-06-28T11:00:00.000Z"));
+
+    expect(await resolveFailedSessionFile(window, dir)).toBeNull();
+  });
+
+  it("returns null (never throws) when the sessions dir does not exist", async () => {
+    const missing = join(tmpdir(), "does-not-exist-sandcastle-sessions-xyz");
+    await expect(resolveFailedSessionFile(window, missing)).resolves.toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #94.

## Problem

A rejected `run()` recorded a `status: "failed"` Manifest entry with `sessionId`/`sessionFile` nulled out, so failed Sessions — the ones you most need to audit — always showed **"not available locally"** in the Session browser's Transcript pager and the render CLI, *even when* the session JSONL had been captured before the crash.

## Change

Resolve the Transcript best-effort on the failure path: scan the sessions dir for the newest session JSONL written within the run's `[startedAt, endedAt]` window and record it on the failed entry.

- **`pickFailedSessionFile(candidates, window)`** — pure, fs-free selector: newest JSONL whose mtime falls in the run window. The window is load-bearing — it excludes JSONL left by *earlier* completed runs, so a run that captured nothing resolves to `null` (unchanged "not available" behavior, no crash) instead of mislinking a prior Transcript.
- **`sessionIdFromFile(file)`** — pure parse of the pi `<stamp>_<sessionId>.jsonl` filename.
- **`resolveFailedSessionFile(window, baseDir)`** — thin fs scan wrapper; never throws (observability must not break the run) — any fs error degrades to `null`.
- **`buildFailedManifestEntry`** gains an optional `session` slice; absent → both fields stay null.
- `recordedRun`'s catch block resolves the session and passes it in.

Setting `sessionFile` to the real JSONL path is sufficient: both the browser pager and CLI go through `resolveTranscriptFile`, which returns an existing `sessionFile` directly.

Note: this best-effort heuristic is newest-in-window (still "unreliable under parallelism", as the prior code comment flagged — several concurrent agents can share a window). The window's lower bound is what guarantees it never mislinks a *previous* run's Transcript.

## Acceptance criteria

- [x] A failed Session whose JSONL was captured is viewable in the browser pager and render CLI
- [x] No JSONL for the run → still renders the existing "not available" note, no crash
- [x] Resolution logic is pure and unit-tested (in-memory + fs fixtures, matching the observability test style)
- [x] Success-path Manifest entries unchanged (`buildManifestEntry` untouched)
- [x] `pnpm typecheck` and `pnpm test` green (454 tests)

## Tests

13 new tests: pure picker window/boundary/exclusion cases, filename parsing, fs fixture-based resolver (incl. "nothing captured → null" and "missing dir → null, never throws"), and the entry-builder link cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)