### PR TITLE
#95 Docs hygiene: add ADR-0002, fix ADR-0006 tail, real CODING_STANDARDS

### DIFF
--- a/.sandcastle/CODING_STANDARDS.md
+++ b/.sandcastle/CODING_STANDARDS.md
@@ -1,54 +1,26 @@
 # Coding Standards
 
-Conventions actually observed in this repo. The Reviewer loads this on every
-review (`@.sandcastle/CODING_STANDARDS.md`) — keep it concise.
+The Reviewer loads this on every review (`@.sandcastle/CODING_STANDARDS.md`) — keep it concise.
 
 ## Architecture: pure-logic / imperative-shell seam
 
-- Split each module into a **pure core** (deterministic, dependency-free logic) and
-  a **thin imperative shell** (I/O, process spawning, React/Ink rendering). Logic
-  lives in the core so it can be pinned by tests; the shell stays thin and
-  untested. Examples: `cockpit-core.mts` (pure) vs `cockpit.tsx` (Ink shell);
-  `SessionBrowser.tsx` (shell) over its core helpers.
-- Keep modules focused on a single responsibility; prefer composition over
-  inheritance. When a behavior is owned by one module (e.g. event rendering lives
-  only in `events.mts`), don't re-implement it elsewhere — call through the seam.
-- Use exhaustiveness guards (`never`) on discriminated-union switches so a new
-  variant fails typecheck rather than silently falling through.
+- Split each module into a **pure core** (deterministic, dependency-free logic) and a **thin imperative shell** (I/O, process spawning, React/Ink rendering). Logic lives in the core so it can be pinned by tests; the shell stays thin and untested Examples: `cockpit-core.mts` (pure) vs `cockpit.tsx` (Ink shell); `SessionBrowser.tsx` (shell) over its core helpers.
+- Keep modules focused on a single responsibility; prefer composition over inheritance. When a behavior is owned by one module (e.g. event rendering lives only in `events.mts`), don't re-implement it elsewhere — call through the seam.
+- Use exhaustiveness guards (`never`) on discriminated-union switches so a new variant fails typecheck rather than silently falling through.
 
 ## Testing (TDD / red-green-refactor)
 
-- Test the **pure side**. Every module with logic has a co-located
-  `*.test.mts`/`*.test.mjs`; React/Ink components are **not** unit-tested (the shell
-  is deliberately thin). Add or update tests in the same change as the logic.
-- Framework is **Vitest** (`describe`/`it`/`expect`, `vi` for mocks). Write
-  descriptive `it(...)` names that state the expected behavior.
+- Test the **pure side**. Every module with logic has a co-located `*.test.mts`/`*.test.mjs`; React/Ink components are **not** unit-tested (the shell is deliberately thin). Add or update tests in the same change as the logic.
+  - It's okay to write tests for react components during TDD, but no need to include them in the commit.
+- Framework is **Vitest** (`describe`/`it`/`expect`, `vi` for mocks). Write descriptive `it(...)` names that state the expected behavior.
 - Work test-first where practical: a failing test, then the code to pass it.
-
-## Modules & imports (`.sandcastle/` is ESM)
-
-- `.sandcastle/` is Node/ESM run under `tsx` — never through the Next.js bundler.
-  Source files are `.mts` (or `.tsx` for Ink, `.mjs` for plain JS).
-- **Import siblings with their explicit file extension**, e.g.
-  `import { ... } from "./events.mts"`. Use `node:` prefixes for builtins
-  (`node:child_process`).
-- Prefer **named exports** over default exports. Use `import type` / `export type`
-  for type-only bindings.
-- `strict` TypeScript is on; typecheck `.sandcastle/` via its dedicated
-  `tsconfig.json` (the root `tsc` skips dot-directories).
 
 ## Naming
 
-- `camelCase` for variables and functions; `PascalCase` for types and classes;
-  `SCREAMING_SNAKE_CASE` for module-level constants (`COCKPIT_TABS`,
-  `MAX_ITERATIONS`).
-- Filenames: `camelCase`/`kebab` for logic modules (`cockpit-core.mts`,
-  `prune-plan.mts`); `PascalCase.tsx` for React components (`SessionBrowser.tsx`).
+- `camelCase` for variables and functions; `PascalCase` for types and classes; `SCREAMING_SNAKE_CASE` for module-level constants (`COCKPIT_TABS`, `MAX_ITERATIONS`).
+- Filenames: `camelCase`/`kebab` for logic modules (`cockpit-core.mts`, `prune-plan.mts`); `PascalCase.tsx` for React components (`SessionBrowser.tsx`).
 
 ## Docs & vocabulary
 
-- Use the **CONTEXT.md glossary** terms verbatim (Transcript, Live feed, Pool,
-  Landing, Poll tick, …) in code, comments, and commit messages. Don't reintroduce
-  the "_Avoid_" synonyms.
-- Non-obvious decisions cite their ADR (`docs/adr/NNNN-*.md`); load-bearing comments
-  explain **why**, not what.
+- Use the **CONTEXT.md glossary** terms verbatim (Transcript, Live feed, Pool, Landing, Poll tick, …) in code, comments, and commit messages. Don't reintroduce the "_Avoid_" synonyms.
+- Non-obvious decisions cite their ADR (`docs/adr/NNNN-*.md`); load-bearing comments explain **why**, not what.

--- a/.sandcastle/CODING_STANDARDS.md
+++ b/.sandcastle/CODING_STANDARDS.md
@@ -1,23 +1,54 @@
 # Coding Standards
 
-<!-- Customize this file with your project's coding standards.
-     The reviewer agent loads it during code review via @.sandcastle/CODING_STANDARDS.md
-     so these standards are enforced during review without costing tokens during implementation. -->
+Conventions actually observed in this repo. The Reviewer loads this on every
+review (`@.sandcastle/CODING_STANDARDS.md`) — keep it concise.
 
-## Style
+## Architecture: pure-logic / imperative-shell seam
 
-- Use camelCase for variables and functions
-- Use PascalCase for classes and types
-- Use PascalCase for filenames for custom React components, for example: `PageHeader.tsx`; but keep next framework specific filenames as-is, for example: `page.tsx`, `layout.tsx`.
-- Use camelCase for filenames for other javascript and typescript files.
-- Prefer named exports over default exports
+- Split each module into a **pure core** (deterministic, dependency-free logic) and
+  a **thin imperative shell** (I/O, process spawning, React/Ink rendering). Logic
+  lives in the core so it can be pinned by tests; the shell stays thin and
+  untested. Examples: `cockpit-core.mts` (pure) vs `cockpit.tsx` (Ink shell);
+  `SessionBrowser.tsx` (shell) over its core helpers.
+- Keep modules focused on a single responsibility; prefer composition over
+  inheritance. When a behavior is owned by one module (e.g. event rendering lives
+  only in `events.mts`), don't re-implement it elsewhere — call through the seam.
+- Use exhaustiveness guards (`never`) on discriminated-union switches so a new
+  variant fails typecheck rather than silently falling through.
 
-## Testing
+## Testing (TDD / red-green-refactor)
 
-- Ensure there are tests for util type functions but no need to add tests for React components
-- Use descriptive test names that explain the expected behavior
+- Test the **pure side**. Every module with logic has a co-located
+  `*.test.mts`/`*.test.mjs`; React/Ink components are **not** unit-tested (the shell
+  is deliberately thin). Add or update tests in the same change as the logic.
+- Framework is **Vitest** (`describe`/`it`/`expect`, `vi` for mocks). Write
+  descriptive `it(...)` names that state the expected behavior.
+- Work test-first where practical: a failing test, then the code to pass it.
 
-## Architecture
+## Modules & imports (`.sandcastle/` is ESM)
 
-- Keep modules focused on a single responsibility
-- Prefer composition over inheritance
+- `.sandcastle/` is Node/ESM run under `tsx` — never through the Next.js bundler.
+  Source files are `.mts` (or `.tsx` for Ink, `.mjs` for plain JS).
+- **Import siblings with their explicit file extension**, e.g.
+  `import { ... } from "./events.mts"`. Use `node:` prefixes for builtins
+  (`node:child_process`).
+- Prefer **named exports** over default exports. Use `import type` / `export type`
+  for type-only bindings.
+- `strict` TypeScript is on; typecheck `.sandcastle/` via its dedicated
+  `tsconfig.json` (the root `tsc` skips dot-directories).
+
+## Naming
+
+- `camelCase` for variables and functions; `PascalCase` for types and classes;
+  `SCREAMING_SNAKE_CASE` for module-level constants (`COCKPIT_TABS`,
+  `MAX_ITERATIONS`).
+- Filenames: `camelCase`/`kebab` for logic modules (`cockpit-core.mts`,
+  `prune-plan.mts`); `PascalCase.tsx` for React components (`SessionBrowser.tsx`).
+
+## Docs & vocabulary
+
+- Use the **CONTEXT.md glossary** terms verbatim (Transcript, Live feed, Pool,
+  Landing, Poll tick, …) in code, comments, and commit messages. Don't reintroduce
+  the "_Avoid_" synonyms.
+- Non-obvious decisions cite their ADR (`docs/adr/NNNN-*.md`); load-bearing comments
+  explain **why**, not what.

--- a/docs/adr/0002-host-access-via-tailscale-ip.md
+++ b/docs/adr/0002-host-access-via-tailscale-ip.md
@@ -1,0 +1,33 @@
+# Reach the host LiteLLM proxy via its Tailscale IP, not `localhost`/bridge gateway
+
+Sandcastle agents run inside Docker sandboxes and call an LLM through a **LiteLLM
+proxy that runs on the host** (baked into the image as pi's `glm-5.1` provider —
+`models.json`, copied to `~/.pi/agent/models.json` in the `Dockerfile`). The
+provider URL points at the host's **Tailscale IP** `100.86.127.113:4000`, not `localhost:4000` or the Docker bridge gateway
+(`host.docker.internal` / `172.17.0.1`).
+
+This machine runs **rootless Docker**, where the usual host-loopback shortcuts do
+not reach a host process bound the way this proxy is: from inside the container,
+`localhost` is the container itself, and the bridge gateway address does not route
+to the proxy. The host's Tailscale IP is a stable address the host answers on that
+the container's bridge network _can_ route to, so **bridge → Tailscale IP is the
+only working path** to the proxy. Hard-coding that IP in the provider config is the
+decision.
+
+The proxy **currently has no master key configured**, so authentication is
+effectively open on the trusted Tailscale network. pi still requires `apiKey` to be
+resolvable, so `.env.example` sets `LITELLM_API_KEY=sk-anything` — any non-empty
+placeholder is accepted at request time.
+
+## Consequences
+
+- **The Tailscale IP is hard-coded** in the image (`models.json`) and referenced in
+  `.sandcastle/.env.example` and the `Dockerfile`. If the host's Tailscale IP
+  changes, or the proxy moves, these must be updated together and the image rebuilt.
+- **No auth boundary at the proxy.** Security rests on the Tailscale network being
+  trusted; the placeholder key is not a secret. If the proxy is ever exposed beyond
+  Tailscale, a real master key must be configured and `LITELLM_API_KEY` threaded
+  through as a genuine secret.
+- **Host-dependent.** The sandbox cannot reach the LLM without the host's LiteLLM
+  proxy running and reachable on Tailscale; this is a local-development assumption,
+  not a portable/CI-ready one.

--- a/docs/adr/0006-persistent-shared-pool-orchestrator.md
+++ b/docs/adr/0006-persistent-shared-pool-orchestrator.md
@@ -116,5 +116,3 @@ Each Poll tick (~60s):
   merged) is unchanged and is exactly what the Dispatch buckets key off.
 - **`plan-prompt.md` barely changes** — the Planner's contract (analyze
   `ready-for-agent`, emit unblocked `sandcastle/issue-N`) is preserved.
-  </content>
-  </invoke>


### PR DESCRIPTION
Closes #95.

Three docs-hygiene items shaping what agents and humans read:

### 1. Dangling ADR-0002
`.sandcastle/.env.example` and the `Dockerfile` referenced `docs/adr/0002-host-access-via-tailscale-ip.md`, which was never committed (the sequence jumped 0001→0003). Wrote the missing one-pager reconstructing the decision from the surrounding comments and `models.json`: the host LiteLLM proxy is reached via the host's **Tailscale IP** `100.86.127.113:4000` because rootless Docker makes bridge → Tailscale IP the only working path, and the proxy has **no master key** (any non-empty `LITELLM_API_KEY` placeholder works). Both references now resolve.

### 2. ADR-0006 tail artifact
Removed the stray copy-paste tokens (`</content>`/`</invoke>`) from the end of `docs/adr/0006-persistent-shared-pool-orchestrator.md`; it now ends cleanly.

### 3. Real CODING_STANDARDS.md
Replaced the unmodified boilerplate template (it still had the "Customize this file" comment) with this repo's actual, observable conventions — the pure-core/imperative-shell seam with tests on the pure side, Vitest + TDD/RGR, ESM/`.mts` explicit-extension imports, named exports, naming, the dedicated `.sandcastle/tsconfig.json`, and CONTEXT.md glossary discipline. Kept concise since the Reviewer loads it every review.

### Acceptance criteria
- [x] No references to nonexistent ADRs remain (only `0001`/`0002` appear as full-path refs; both exist)
- [x] ADR-0006 ends cleanly with no stray artifact
- [x] CODING_STANDARDS.md no longer contains template boilerplate and states conventions actually observable in this repo
- [x] The Reviewer prompt's `@.sandcastle/CODING_STANDARDS.md` reference still resolves

Docs/markdown only — no code or typecheck surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)