### PR TITLE
#96 Reviewer reports an Outcome; orchestrator owns terminal transitions (ADR-0011)

### DIFF
--- a/.sandcastle/cockpit-core.test.mts
+++ b/.sandcastle/cockpit-core.test.mts
@@ -270,6 +270,23 @@ describe("formatEventLog", () => {
     expect(
       formatEventLog(evt({ type: "gh-error", args: ["issue", "list"], error: "rate limited" }))
     ).toBe("⚠ gh issue list failed · rate limited");
+    expect(
+      formatEventLog(evt({ type: "reviewer-outcome", issue: 7, outcome: "pass", reason: null }))
+    ).toBe("✓ rev #7 outcome · pass");
+    expect(
+      formatEventLog(
+        evt({ type: "reviewer-outcome", issue: 7, outcome: "give-up", reason: "the suite is red" })
+      )
+    ).toBe("⚠ rev #7 outcome · give-up · the suite is red");
+    expect(
+      formatEventLog(evt({ type: "reviewer-outcome", issue: 7, outcome: "none", reason: null }))
+    ).toBe("⚠ rev #7 outcome · none");
+    expect(formatEventLog(evt({ type: "review-transition", issue: 7, transition: "gate" }))).toBe(
+      "→ #7 gate opened · reviewed + ready"
+    );
+    expect(
+      formatEventLog(evt({ type: "review-transition", issue: 7, transition: "give-up" }))
+    ).toBe("→ #7 escalated to ready-for-human");
   });
 });
 

--- a/.sandcastle/dispatch.mts
+++ b/.sandcastle/dispatch.mts
@@ -343,11 +343,99 @@ export function pickPrs<T extends BucketPr>(
 /**
  * How the orchestrator talks to the `gh` CLI for terminal handling. `run`
  * executes one command and rejects on a non-zero exit (like `execFile`);
- * `handleImplementerOutcome` only tolerates failure on the defensive
- * `label create` step.
+ * `handleImplementerOutcome` / `handleReviewerOutcome` only tolerate failure on
+ * the defensive `label create` step.
  */
 export interface GhRunner {
   run(args: string[]): Promise<unknown>;
+}
+
+/** A `gh` label's create spec — its name plus the description/colour used the
+ *  first time it is created. */
+interface LabelSpec {
+  readonly name: string;
+  readonly description: string;
+  readonly color: string;
+}
+
+/** The universal terminal label (CONTEXT.md: ready-for-human) every give-up /
+ *  failure path lands on. */
+const READY_FOR_HUMAN: LabelSpec = {
+  name: "ready-for-human",
+  description: "Out of all Dispatch buckets; a human owns it",
+  color: "0052CC",
+};
+
+/** The review-gate label a passing Reviewer's PR carries so a Merger can land it. */
+const REVIEWED: LabelSpec = {
+  name: "reviewed",
+  description: "Reviewed by the Sandcastle Reviewer",
+  color: "0E8A16",
+};
+
+/**
+ * Best-effort `gh label create`: defensively ensure a label exists before a
+ * transition adds it. A non-zero exit (the label already exists) is expected and
+ * swallowed — a terminal transition must never abort because a label was already
+ * there. Mirrors the `gh label create … || true` the prompts used to run.
+ */
+async function ensureLabel(gh: GhRunner, label: LabelSpec): Promise<void> {
+  try {
+    await gh.run([
+      "label",
+      "create",
+      label.name,
+      "--description",
+      label.description,
+      "--color",
+      label.color,
+    ]);
+  } catch {
+    /* label already exists — best effort */
+  }
+}
+
+// ---- The Outcome contract (ADR-0011) --------------------------------------
+
+/**
+ * The structured self-report a Reviewer Session ends with (CONTEXT.md: Outcome):
+ * `pass` (the change is good — open the review gate) or `give-up` with a
+ * one-line reason (hand the PR to a human). The orchestrator parses it from the
+ * agent's final output and performs every dispatch-controlling transition
+ * itself; the agent never runs `gh` to mutate labels/draft state (ADR-0011).
+ */
+export type ParsedOutcome =
+  | { readonly kind: "pass" }
+  | { readonly kind: "give-up"; readonly reason: string };
+
+/**
+ * Parse the Outcome tag out of a Reviewer's final output — the same shape as the
+ * Planner's `<plan>` block (`main.mts`):
+ *
+ * ```
+ * <outcome>pass</outcome>
+ * <outcome>give-up: <one-line reason></outcome>
+ * ```
+ *
+ * The **last** tag wins (an agent may restate the format earlier in its
+ * reasoning; the closing verdict is authoritative). Whitespace inside the tag is
+ * tolerated. Returns `null` for a missing OR garbled verdict (anything that is
+ * not exactly `pass` or `give-up: <non-empty reason>`) — a null is NOT a
+ * give-up: it triggers no GitHub mutation and is recorded as a failed attempt
+ * against the (future) Retry budget, so one formatting lapse never escalates
+ * automatable work to a human (ADR-0011).
+ *
+ * Pure and side-effect-free so the contract is unit-testable in isolation.
+ */
+export function parseOutcome(text: string): ParsedOutcome | null {
+  const matches = [...text.matchAll(/<outcome>([\s\S]*?)<\/outcome>/g)];
+  const last = matches[matches.length - 1];
+  if (!last) return null;
+  const body = last[1].trim();
+  if (body === "pass") return { kind: "pass" };
+  const giveUp = body.match(/^give-up:\s*(\S[\s\S]*)$/);
+  if (giveUp) return { kind: "give-up", reason: giveUp[1].trim() };
+  return null;
 }
 
 /**
@@ -360,6 +448,67 @@ export const NOOP_IMPLEMENTER_COMMENT =
   "Escalating to `ready-for-human` (out of all Dispatch buckets; a human owns it) so the " +
   "issue is not re-dispatched every tick. One no-op is a strong signal the issue is not " +
   "actually agent-ready.";
+
+/** Which terminal transition `handleReviewerOutcome` applied: the review `gate`
+ *  (pass → reviewed + ready) or a `give-up` escalation (→ ready-for-human). */
+export type ReviewTransition = "gate" | "give-up";
+
+/**
+ * Comment body the orchestrator posts when a Reviewer's Outcome is `give-up`
+ * (ADR-0011). Carries the agent's one-line reason plus the CONTEXT.md
+ * `ready-for-human` semantics — pins the wording that used to live in the
+ * review prompt's GIVE-UP PATH, now owned by orchestrator code. Exported so it
+ * is documented and unit-testable.
+ */
+export function reviewerGiveUpComment(reason: string): string {
+  return (
+    `Sandcastle Reviewer could not pass this change: ${reason}\n\n` +
+    "Escalating to `ready-for-human` (out of all Dispatch buckets; a human owns it). " +
+    "The PR stays a draft — it is never marked ready or merged from here."
+  );
+}
+
+/**
+ * Reviewer Outcome terminal handling (CONTEXT.md: Outcome; ADR-0011). The agent
+ * judged; this code mutates the dispatch-controlling GitHub state — the agent no
+ * longer runs `gh` to flip labels/draft from prompt instructions. Pure logic
+ * over an injectable {@link GhRunner}, so every transition is unit-testable.
+ *
+ * - **pass** → open the review gate so a Merger can land the PR: defensively
+ *   ensure the `reviewed` label exists, **add `reviewed` before flipping the PR
+ *   draft → ready** (so the PR is never momentarily ready without `reviewed`,
+ *   which would sit in no Dispatch bucket). Returns `"gate"`.
+ * - **give-up** → hand the PR to a human: defensively ensure `ready-for-human`
+ *   exists, **add `ready-for-human` before any other state change** (the
+ *   crash-safe ordering rule — the terminal label lands first, so no crash point
+ *   strands the PR outside every bucket), then post the reason as a PR comment.
+ *   The PR is left a draft. Returns `"give-up"`.
+ *
+ * The caller only invokes this for a *parsed* Outcome; a missing/garbled Outcome
+ * (`parseOutcome` → null) performs no mutation at all and is left to the Retry
+ * budget (ADR-0011).
+ */
+export async function handleReviewerOutcome(
+  outcome: ParsedOutcome,
+  pr: { readonly prNumber: number },
+  gh: GhRunner
+): Promise<ReviewTransition> {
+  const n = String(pr.prNumber);
+  if (outcome.kind === "pass") {
+    await ensureLabel(gh, REVIEWED);
+    // Add `reviewed` BEFORE flipping to ready so the PR is never ready-without-
+    // reviewed (which would sit in no bucket).
+    await gh.run(["pr", "edit", n, "--add-label", "reviewed"]);
+    await gh.run(["pr", "ready", n]);
+    return "gate";
+  }
+
+  // give-up: apply the terminal label FIRST (crash-safe), then comment.
+  await ensureLabel(gh, READY_FOR_HUMAN);
+  await gh.run(["pr", "edit", n, "--add-label", "ready-for-human"]);
+  await gh.run(["pr", "comment", n, "--body", reviewerGiveUpComment(outcome.reason)]);
+  return "give-up";
+}
 
 /**
  * No-op Implementer terminal handling (CONTEXT.md: ready-for-human; ADR-0006).
@@ -388,22 +537,9 @@ export async function handleImplementerOutcome(
   if (commits > 0) return false;
 
   const n = String(issueNumber);
-  // Defensive: ensure the terminal label exists (mirrors the review/merge
-  // prompts' `gh label create … || true`). A non-zero exit here (label already
-  // exists) is expected and ignored — escalation must not abort.
-  try {
-    await gh.run([
-      "label",
-      "create",
-      "ready-for-human",
-      "--description",
-      "Out of all Dispatch buckets; a human owns it",
-      "--color",
-      "0052CC",
-    ]);
-  } catch {
-    /* label already exists — best effort */
-  }
+  // Defensive: ensure the terminal label exists before adding it (escalation
+  // must not abort if the label is already there).
+  await ensureLabel(gh, READY_FOR_HUMAN);
   // Add the terminal label BEFORE removing the bucket label so the issue is
   // never without either.
   await gh.run(["issue", "edit", n, "--add-label", "ready-for-human"]);

--- a/.sandcastle/dispatch.test.mts
+++ b/.sandcastle/dispatch.test.mts
@@ -11,17 +11,21 @@ import {
   filterReadyForMerge,
   filterReadyForReview,
   handleImplementerOutcome,
+  handleReviewerOutcome,
   issueFromBranch,
+  parseOutcome,
   pickImplementers,
   pickPrs,
   planCacheKey,
   resolvePlanEmit,
+  reviewerGiveUpComment,
   shouldQueryBuckets,
   shouldReusePlan,
   shouldRunPlanner,
   type BucketPr,
   type EmittedIssue,
   type GhRunner,
+  type ParsedOutcome,
   type PlanCache,
   type ReadyForAgentIssue,
 } from "./dispatch.mts";
@@ -301,6 +305,129 @@ describe("handleImplementerOutcome", () => {
   it("comments with the CONTEXT.md ready-for-human semantics", async () => {
     expect(NOOP_IMPLEMENTER_COMMENT).toMatch(/no commits/i);
     expect(NOOP_IMPLEMENTER_COMMENT).toMatch(/out of all Dispatch buckets; a human owns it/i);
+  });
+});
+
+// ---- #96 — the Outcome contract (ADR-0011) --------------------------------
+//
+// The Reviewer ends its Session with a structured Outcome tag the orchestrator
+// parses (like the Planner's <plan> block) and acts on. `parseOutcome` is the
+// pure parser; `handleReviewerOutcome` is the pure transition logic over an
+// injectable gh runner. A garbled / missing tag parses to `null` — no GitHub
+// mutation, the Session is a failed attempt against the (future) Retry budget.
+
+describe("parseOutcome", () => {
+  it("parses a pass verdict", () => {
+    expect(parseOutcome("all good\n<outcome>pass</outcome>\n")).toEqual({ kind: "pass" });
+  });
+
+  it("parses a give-up verdict with its one-line reason", () => {
+    expect(parseOutcome("<outcome>give-up: the suite is red and I can't fix it</outcome>")).toEqual(
+      {
+        kind: "give-up",
+        reason: "the suite is red and I can't fix it",
+      }
+    );
+  });
+
+  it("tolerates whitespace inside the tag", () => {
+    expect(parseOutcome("<outcome>  pass  </outcome>")).toEqual({ kind: "pass" });
+    expect(parseOutcome("<outcome> give-up:   missing dependency </outcome>")).toEqual({
+      kind: "give-up",
+      reason: "missing dependency",
+    });
+  });
+
+  it("takes the LAST tag when the agent restated the format earlier", () => {
+    const text = "example: <outcome>pass</outcome>\n...\nfinal: <outcome>give-up: nope</outcome>";
+    expect(parseOutcome(text)).toEqual({ kind: "give-up", reason: "nope" });
+  });
+
+  it("returns null when no tag is present (folds into the Retry budget)", () => {
+    expect(parseOutcome("I reviewed it and it looks fine.")).toBeNull();
+  });
+
+  it("returns null for a garbled verdict (not pass, not give-up:reason)", () => {
+    expect(parseOutcome("<outcome>looks good to me</outcome>")).toBeNull();
+    expect(parseOutcome("<outcome>give-up</outcome>")).toBeNull(); // no reason
+    expect(parseOutcome("<outcome>give-up:   </outcome>")).toBeNull(); // empty reason
+  });
+});
+
+describe("handleReviewerOutcome", () => {
+  const pass: ParsedOutcome = { kind: "pass" };
+  const giveUp: ParsedOutcome = { kind: "give-up", reason: "the suite is red" };
+
+  it("pass → opens the review gate: adds reviewed then flips the PR to ready", async () => {
+    const gh = mockGh();
+    const transition = await handleReviewerOutcome(pass, { prNumber: 7 }, gh);
+    expect(transition).toBe("gate");
+    const calls = gh.calls.map((c) => c.join(" "));
+    expect(calls.some((s) => /pr edit 7 --add-label reviewed/.test(s))).toBe(true);
+    expect(calls.some((s) => /pr ready 7/.test(s))).toBe(true);
+    // no terminal escalation on a pass
+    expect(calls.some((s) => /ready-for-human/.test(s))).toBe(false);
+  });
+
+  it("pass → adds the reviewed label BEFORE flipping to ready (never ready+unreviewed)", async () => {
+    const gh = mockGh();
+    await handleReviewerOutcome(pass, { prNumber: 7 }, gh);
+    const labelIdx = gh.calls.findIndex((c) => c.includes("--add-label"));
+    const readyIdx = gh.calls.findIndex((c) => c[0] === "pr" && c[1] === "ready");
+    expect(labelIdx).toBeGreaterThan(-1);
+    expect(readyIdx).toBeGreaterThan(-1);
+    expect(labelIdx).toBeLessThan(readyIdx);
+  });
+
+  it("pass → creates the reviewed label defensively and tolerates 'already exists'", async () => {
+    const gh = mockGh(true); // the label create throws
+    const transition = await handleReviewerOutcome(pass, { prNumber: 7 }, gh);
+    expect(transition).toBe("gate"); // best-effort create must not abort the gate
+    expect(gh.calls.some((c) => c[0] === "label" && c[1] === "create" && c[2] === "reviewed")).toBe(
+      true
+    );
+    const calls = gh.calls.map((c) => c.join(" "));
+    expect(calls.some((s) => /pr edit 7 --add-label reviewed/.test(s))).toBe(true);
+    expect(calls.some((s) => /pr ready 7/.test(s))).toBe(true);
+  });
+
+  it("give-up → escalates to ready-for-human and posts the reason; PR stays draft", async () => {
+    const gh = mockGh();
+    const transition = await handleReviewerOutcome(giveUp, { prNumber: 7 }, gh);
+    expect(transition).toBe("give-up");
+    const calls = gh.calls.map((c) => c.join(" "));
+    expect(calls.some((s) => /pr edit 7 --add-label ready-for-human/.test(s))).toBe(true);
+    expect(calls.some((s) => /pr comment 7 --body/.test(s))).toBe(true);
+    // the PR is NOT flipped to ready and is NOT marked reviewed
+    expect(calls.some((s) => /pr ready 7/.test(s))).toBe(false);
+    expect(calls.some((s) => /--add-label reviewed/.test(s))).toBe(false);
+  });
+
+  it("give-up → applies ready-for-human BEFORE any other state change (crash-safe)", async () => {
+    const gh = mockGh();
+    await handleReviewerOutcome(giveUp, { prNumber: 7 }, gh);
+    const addIdx = gh.calls.findIndex((c) => c.includes("--add-label"));
+    const commentIdx = gh.calls.findIndex((c) => c[1] === "comment");
+    expect(addIdx).toBeGreaterThan(-1);
+    expect(commentIdx).toBeGreaterThan(-1);
+    expect(addIdx).toBeLessThan(commentIdx);
+  });
+
+  it("give-up → posts the reason with the ready-for-human semantics", async () => {
+    const gh = mockGh();
+    await handleReviewerOutcome(giveUp, { prNumber: 7 }, gh);
+    const comment = gh.calls.find((c) => c[1] === "comment")!;
+    const body = comment[comment.length - 1];
+    expect(body).toContain("the suite is red");
+    expect(body).toMatch(/out of all Dispatch buckets; a human owns it/i);
+  });
+});
+
+describe("reviewerGiveUpComment", () => {
+  it("includes the reason and the CONTEXT.md ready-for-human semantics", () => {
+    const body = reviewerGiveUpComment("missing dependency");
+    expect(body).toContain("missing dependency");
+    expect(body).toMatch(/out of all Dispatch buckets; a human owns it/i);
   });
 });
 
@@ -739,5 +866,36 @@ describe("main.mts — Plan cache wiring (ADR-0010, #86)", () => {
     // A cache hit skips the LLM, never the dispatch — capped emits still drain.
     expect(mainSource).toMatch(/resolved\.emit\.filter/);
     expect(mainSource).toMatch(/pickImplementers\(dispatchable, remaining, inflight\)/);
+  });
+});
+
+describe("main.mts — Reviewer Outcome handling (ADR-0011, #96)", () => {
+  it("parses the Reviewer's Outcome from its output (like the Planner's <plan>)", () => {
+    expect(mainSource).toMatch(/parseOutcome\(/);
+  });
+
+  it("performs the terminal transition itself via handleReviewerOutcome", () => {
+    expect(mainSource).toMatch(/handleReviewerOutcome\(/);
+  });
+
+  it("only mutates GitHub state when an Outcome actually parsed (null → no mutation)", () => {
+    // A missing/garbled Outcome parses to null; handleReviewerOutcome is guarded
+    // behind an `if (outcome)` so no GitHub mutation happens (Retry-budget path).
+    expect(mainSource).toMatch(/if\s*\(\s*outcome\s*\)/);
+  });
+
+  it("emits Live-feed events for the parsed Outcome and the applied transition", () => {
+    expect(mainSource).toMatch(/events\.reviewerOutcome\(/);
+    expect(mainSource).toMatch(/events\.reviewTransition\(/);
+  });
+
+  it("records the parsed Outcome in the Manifest (recordedRun outcome extractor)", () => {
+    expect(mainSource).toMatch(/outcome:\s*\(r\)\s*=>\s*parseOutcome\(r\.stdout\)/);
+  });
+
+  it("no longer leaves the review gate / give-up path to the prompt", () => {
+    // The old comment claimed "Reviewer/Merger give-up paths live in the prompts";
+    // the Reviewer's now lives in code (ADR-0011).
+    expect(mainSource).not.toMatch(/give-up path.*live.*in the prompt/i);
   });
 });

--- a/.sandcastle/events.mts
+++ b/.sandcastle/events.mts
@@ -134,6 +134,25 @@ interface SessionResolvedEvent extends BaseEvent {
   readonly error: string | null;
 }
 
+/** The orchestrator parsed a Reviewer Session's Outcome (ADR-0011): `pass`,
+ *  `give-up` (with its one-line `reason`), or `none` when the Session produced
+ *  no parseable Outcome tag (no GitHub mutation — a Retry-budget attempt). */
+interface ReviewerOutcomeEvent extends BaseEvent {
+  readonly type: "reviewer-outcome";
+  readonly issue: number;
+  readonly outcome: "pass" | "give-up" | "none";
+  readonly reason: string | null;
+}
+
+/** The orchestrator applied a Reviewer terminal transition from the parsed
+ *  Outcome (ADR-0011): `gate` (pass → `reviewed` + PR ready) or `give-up`
+ *  (→ `ready-for-human`, PR left draft). */
+interface ReviewTransitionEvent extends BaseEvent {
+  readonly type: "review-transition";
+  readonly issue: number;
+  readonly transition: "gate" | "give-up";
+}
+
 /**
  * The discriminated union of every orchestrator event. `type` is the single
  * discriminator the renderers switch on; the contract the Cockpit consumes.
@@ -150,7 +169,9 @@ export type OrchestratorEvent =
   | PlannerFailedEvent
   | NoopEscalatedEvent
   | GhErrorEvent
-  | SessionResolvedEvent;
+  | SessionResolvedEvent
+  | ReviewerOutcomeEvent
+  | ReviewTransitionEvent;
 
 /** Which stdout stream a prose-rendered event belongs on (preserves the
  *  existing stdout/stderr split so headless output is unchanged). */
@@ -194,6 +215,15 @@ export function formatEventProse(event: OrchestratorEvent): string | null {
     case "session-resolved":
       if (event.status === "ok") return null;
       return `  ✗ ${roleFailedPrefix(event.role)}#${event.issue} (${event.branch}) failed: ${event.error}`;
+    case "reviewer-outcome":
+      if (event.outcome === "pass") return `  ✓ Reviewer #${event.issue} reported pass.`;
+      if (event.outcome === "give-up")
+        return `  ⚠ Reviewer #${event.issue} gave up: ${event.reason}`;
+      return `  ⚠ Reviewer #${event.issue} reported no parseable Outcome — no state change.`;
+    case "review-transition":
+      return event.transition === "gate"
+        ? `  → review gate opened for #${event.issue} (reviewed + ready).`
+        : `  → #${event.issue} escalated to ready-for-human (Reviewer gave up).`;
   }
 }
 
@@ -291,6 +321,15 @@ export function formatEventLog(event: OrchestratorEvent): string {
       return `⚠ #${event.issue} no commits · escalated to ready-for-human`;
     case "gh-error":
       return `⚠ gh ${event.args.join(" ")} failed · ${event.error}`;
+    case "reviewer-outcome":
+      if (event.outcome === "give-up")
+        return `⚠ rev #${event.issue} outcome · give-up · ${event.reason}`;
+      if (event.outcome === "none") return `⚠ rev #${event.issue} outcome · none`;
+      return `✓ rev #${event.issue} outcome · pass`;
+    case "review-transition":
+      return event.transition === "gate"
+        ? `→ #${event.issue} gate opened · reviewed + ready`
+        : `→ #${event.issue} escalated to ready-for-human`;
     default: {
       // Exhaustiveness guard: adding a new OrchestratorEvent type without a log
       // line here is a compile error, so the Live log can never silently omit one.
@@ -320,6 +359,10 @@ export function eventSeverity(event: OrchestratorEvent): EventSeverity {
     case "noop-escalated":
     case "planner-no-plan":
       return "warn";
+    case "reviewer-outcome":
+      // A give-up or no-parseable-Outcome is a soft escalation (warn); a pass is
+      // routine progress (normal).
+      return event.outcome === "pass" ? "normal" : "warn";
     case "tick":
     case "pool-full":
     case "buckets":
@@ -327,6 +370,7 @@ export function eventSeverity(event: OrchestratorEvent): EventSeverity {
     case "planner-emitted":
     case "plan-reused":
     case "planner-skipped":
+    case "review-transition":
       return "normal";
     default: {
       const unreachable: never = event;
@@ -355,6 +399,8 @@ const EVENT_TYPE_TAGS: Record<OrchestratorEvent["type"], true> = {
   "noop-escalated": true,
   "gh-error": true,
   "session-resolved": true,
+  "reviewer-outcome": true,
+  "review-transition": true,
 };
 
 /** Every `type` discriminator the orchestrator can emit, derived from the union
@@ -434,6 +480,12 @@ export interface OrchestratorEvents {
   noopEscalated(issue: number): void;
   /** A per-tick `gh` query failed (tolerated; next tick re-queries). */
   ghError(args: ReadonlyArray<string>, error: string): void;
+  /** The Reviewer's parsed Outcome (ADR-0011): `pass` / `give-up` (with
+   *  `reason`) / `none` when no parseable Outcome tag was produced. */
+  reviewerOutcome(issue: number, outcome: "pass" | "give-up" | "none", reason: string | null): void;
+  /** The applied Reviewer terminal transition: `gate` (reviewed + ready) or
+   *  `give-up` (ready-for-human). */
+  reviewTransition(issue: number, transition: "gate" | "give-up"): void;
 }
 
 /** Options for {@link createEvents}; every dependency is injectable for tests. */
@@ -502,5 +554,9 @@ export function createEvents(opts: CreateEventsOptions = {}): OrchestratorEvents
       }),
     noopEscalated: (issue) => emit({ type: "noop-escalated", issue, ts: stamp() }),
     ghError: (args, error) => emit({ type: "gh-error", args, error, ts: stamp() }),
+    reviewerOutcome: (issue, outcome, reason) =>
+      emit({ type: "reviewer-outcome", issue, outcome, reason, ts: stamp() }),
+    reviewTransition: (issue, transition) =>
+      emit({ type: "review-transition", issue, transition, ts: stamp() }),
   };
 }

--- a/.sandcastle/events.test.mts
+++ b/.sandcastle/events.test.mts
@@ -141,6 +141,29 @@ describe("formatEventProse", () => {
     ).toBe("  ⚠ gh pr list --state open failed: nope");
   });
 
+  it("renders the parsed Reviewer Outcome (pass / give-up / none)", () => {
+    expect(
+      formatEventProse(evt({ type: "reviewer-outcome", issue: 7, outcome: "pass", reason: null }))
+    ).toBe("  ✓ Reviewer #7 reported pass.");
+    expect(
+      formatEventProse(
+        evt({ type: "reviewer-outcome", issue: 7, outcome: "give-up", reason: "the suite is red" })
+      )
+    ).toBe("  ⚠ Reviewer #7 gave up: the suite is red");
+    expect(
+      formatEventProse(evt({ type: "reviewer-outcome", issue: 7, outcome: "none", reason: null }))
+    ).toBe("  ⚠ Reviewer #7 reported no parseable Outcome — no state change.");
+  });
+
+  it("renders the applied Reviewer transition (gate / give-up)", () => {
+    expect(formatEventProse(evt({ type: "review-transition", issue: 7, transition: "gate" }))).toBe(
+      "  → review gate opened for #7 (reviewed + ready)."
+    );
+    expect(
+      formatEventProse(evt({ type: "review-transition", issue: 7, transition: "give-up" }))
+    ).toBe("  → #7 escalated to ready-for-human (Reviewer gave up).");
+  });
+
   it("renders nothing for a successful session-resolved (headless prose unchanged)", () => {
     expect(
       formatEventProse(
@@ -262,6 +285,15 @@ describe("eventStream", () => {
     expect(eventStream(evt({ type: "gh-error", args: ["a"], error: "x" }))).toBe("stderr");
     expect(eventStream(evt({ type: "planner-no-plan" }))).toBe("stderr");
     expect(eventStream(evt({ type: "planner-failed", error: "x" }))).toBe("stderr");
+  });
+
+  it("routes the reviewer Outcome + transition events to stdout (orchestrator progress)", () => {
+    expect(
+      eventStream(evt({ type: "reviewer-outcome", issue: 7, outcome: "give-up", reason: "red" }))
+    ).toBe("stdout");
+    expect(eventStream(evt({ type: "review-transition", issue: 7, transition: "give-up" }))).toBe(
+      "stdout"
+    );
   });
 
   it("routes a failed session-resolved to stderr but a successful one to stdout", () => {
@@ -414,6 +446,19 @@ describe("createEvents", () => {
     expect(err).toHaveBeenCalledWith("  ✗ rev #9 (sandcastle/issue-9) failed: kaboom");
   });
 
+  it("emits the reviewer Outcome + transition through the prose renderer", () => {
+    const out = vi.fn();
+    const err = vi.fn();
+    const events = createEvents({ format: "prose", out, err });
+    events.reviewerOutcome(7, "give-up", "the suite is red");
+    events.reviewTransition(7, "give-up");
+    expect(out).toHaveBeenNthCalledWith(1, "  ⚠ Reviewer #7 gave up: the suite is red");
+    expect(out).toHaveBeenNthCalledWith(
+      2,
+      "  → #7 escalated to ready-for-human (Reviewer gave up)."
+    );
+  });
+
   it("in ndjson mode writes every event as one JSON object to `out` (incl. silent-in-prose ones)", () => {
     const out = vi.fn();
     const err = vi.fn();
@@ -520,6 +565,8 @@ describe("EVENT_TYPES / isKnownEventType", () => {
     "noop-escalated",
     "gh-error",
     "session-resolved",
+    "reviewer-outcome",
+    "review-transition",
   ];
 
   it("contains exactly every orchestrator event type, no more, no fewer", () => {
@@ -557,11 +604,23 @@ describe("eventSeverity", () => {
   it("classifies soft escalations as warn", () => {
     expect(eventSeverity(evt({ type: "noop-escalated", issue: 1 }))).toBe("warn");
     expect(eventSeverity(evt({ type: "planner-no-plan" }))).toBe("warn");
+    expect(
+      eventSeverity(evt({ type: "reviewer-outcome", issue: 1, outcome: "give-up", reason: "x" }))
+    ).toBe("warn");
+    expect(
+      eventSeverity(evt({ type: "reviewer-outcome", issue: 1, outcome: "none", reason: null }))
+    ).toBe("warn");
   });
 
   it("classifies progress events (incl. a successful resolution) as normal", () => {
     expect(eventSeverity(evt({ type: "tick", free: 1, poolSize: 10, inflight: 0 }))).toBe("normal");
     expect(eventSeverity(evt({ type: "planner-emitted", count: 1 }))).toBe("normal");
+    expect(
+      eventSeverity(evt({ type: "reviewer-outcome", issue: 1, outcome: "pass", reason: null }))
+    ).toBe("normal");
+    expect(eventSeverity(evt({ type: "review-transition", issue: 1, transition: "gate" }))).toBe(
+      "normal"
+    );
     expect(
       eventSeverity(
         evt({

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -9,7 +9,9 @@ import {
   filterReadyForMerge,
   filterReadyForReview,
   handleImplementerOutcome,
+  handleReviewerOutcome,
   issueFromBranch,
+  parseOutcome,
   pickImplementers,
   pickPrs,
   POLL_INTERVAL_MS,
@@ -19,6 +21,7 @@ import {
   shouldRunPlanner,
   type BucketPr,
   type EmittedIssue,
+  type ParsedOutcome,
   type PlanCache,
   type ReadyForAgentIssue,
 } from "./dispatch.mts";
@@ -80,6 +83,10 @@ async function recordedRun<R extends RunLike>(args: {
   issue?: number | null;
   branch?: string | null;
   run: () => Promise<R>;
+  /** Extract the Session's structured Outcome from its result for the Manifest
+   *  (ADR-0011). Given for the Reviewer (parses its `<outcome>` tag); omitted for
+   *  phases that report none (impl/planner/merger) — the entry records null. */
+  outcome?: (result: R) => ParsedOutcome | null;
 }): Promise<R> {
   const startedAt = new Date();
   try {
@@ -93,6 +100,7 @@ async function recordedRun<R extends RunLike>(args: {
         result,
         startedAt,
         endedAt: new Date(),
+        outcome: args.outcome?.(result) ?? null,
       })
     );
     return result;
@@ -217,8 +225,10 @@ async function queryReviewMergePrs(): Promise<BucketPr[]> {
   return prs;
 }
 
-/** The escalation `gh` runner handed to `handleImplementerOutcome`. */
-const escalateGh = { run: async (args: string[]) => void (await gh(args)) };
+/** The `gh` runner handed to the pure terminal-transition handlers
+ *  (`handleImplementerOutcome`, `handleReviewerOutcome`): runs one `gh` command
+ *  and resolves on success / rejects on non-zero exit. */
+const ghRunner = { run: async (args: string[]) => void (await gh(args)) };
 
 /** The typed orchestrator event stream (ADR-0008): every progress moment
  *  flows through this one emitter as a discriminated union, with a prose
@@ -239,7 +249,9 @@ const events = createEvents();
 // a slot remains free after merge+review draining. Reviewers/Mergers each build
 // their own fresh sandbox (impl and review are decoupled across ticks) and run
 // the issue-derived `runId`. A no-op Implementer is escalated to ready-for-human
-// so it is not re-dispatched; Reviewer/Merger give-up paths live in the prompts (#65).
+// so it is not re-dispatched. The Reviewer reports an Outcome the orchestrator
+// acts on — the review gate + give-up transitions are performed here in code
+// (ADR-0011, #96); the Merger's give-up path still lives in its prompt (ADR-0012).
 const pool = createPool(POOL_SIZE);
 const inflight = createInflight();
 
@@ -318,11 +330,7 @@ async function dispatchImplementer(issue: {
 
     // No-op terminal handling (ADR-0006): zero commits → no draft PR → strip
     // ready-for-agent, add ready-for-human, comment, so it is not re-dispatched.
-    const escalated = await handleImplementerOutcome(
-      issue.number,
-      result.commits.length,
-      escalateGh
-    );
+    const escalated = await handleImplementerOutcome(issue.number, result.commits.length, ghRunner);
     if (escalated) {
       events.noopEscalated(issue.number);
     }
@@ -347,12 +355,16 @@ async function dispatchImplementer(issue: {
  * (acquire), marks the issue in-flight, opens a **fresh sandbox from the PR
  * branch** (impl and review are decoupled across ticks per ADR-0006, so the
  * Reviewer cannot reuse the Implementer's live sandbox), re-runs install+build,
- * and runs review-prompt.md. The Reviewer commits fixes itself (Model A) and,
- * when the change passes, opens the REVIEW GATE (adds `reviewed`, flips the PR
- * draft → ready) so the Merger can land it; its give-up path escalates to
- * `ready-for-human` inside the prompt (#65). Whatever happens, the finally
- * disposes the sandbox, removes the issue from the In-flight set, and frees the
- * Pool slot. The runId is issue-derived, shared with the issue's impl/merger.
+ * and runs review-prompt.md. The Reviewer commits fixes itself (Model A), posts
+ * a prose review-summary comment, and ends its Session with a structured
+ * **Outcome** (`<outcome>pass</outcome>` / `<outcome>give-up: …</outcome>`). The
+ * orchestrator parses it and performs every dispatch-controlling transition
+ * itself (ADR-0011): on `pass` it opens the review gate (adds `reviewed`, flips
+ * the PR draft → ready); on `give-up` it escalates to `ready-for-human` (PR left
+ * draft). A missing/garbled Outcome triggers no GitHub mutation (a Retry-budget
+ * attempt) — it is recorded in the Manifest and surfaced as an event. Whatever
+ * happens, the finally disposes the sandbox, removes the issue from the In-flight
+ * set, and frees the Pool slot. The runId is issue-derived, shared with impl.
  */
 async function dispatchReviewer(pr: {
   prNumber: number;
@@ -382,6 +394,8 @@ async function dispatchReviewer(pr: {
       phase: "rev",
       issue: pr.issue,
       branch: pr.branch,
+      // ADR-0011: record the Reviewer's parsed Outcome in the Manifest entry.
+      outcome: (r) => parseOutcome(r.stdout),
       run: () =>
         sandbox.run({
           name: "Reviewer #" + pr.issue,
@@ -405,6 +419,21 @@ async function dispatchReviewer(pr: {
       status: "ok",
       commits: result.commits.length,
     });
+
+    // ADR-0011: the agent judged; the orchestrator mutates. Parse the reported
+    // Outcome and perform the terminal transition ourselves. A missing/garbled
+    // Outcome (parseOutcome → null) triggers NO GitHub mutation — the review is
+    // left for re-dispatch (a Retry-budget attempt in a follow-up issue).
+    const outcome = parseOutcome(result.stdout);
+    events.reviewerOutcome(
+      pr.issue,
+      outcome?.kind ?? "none",
+      outcome?.kind === "give-up" ? outcome.reason : null
+    );
+    if (outcome) {
+      const transition = await handleReviewerOutcome(outcome, pr, ghRunner);
+      events.reviewTransition(pr.issue, transition);
+    }
   } catch (err) {
     events.sessionResolved({
       role: "reviewer",

--- a/.sandcastle/observability.mts
+++ b/.sandcastle/observability.mts
@@ -47,6 +47,7 @@ import type {
   IterationUsage,
   LoggingOption,
 } from "@ai-hero/sandcastle";
+import type { ParsedOutcome } from "./dispatch.mts";
 
 const TOOL_GLYPH = "▶";
 const TEXT_GLYPH = "»";
@@ -291,6 +292,11 @@ export interface ManifestEntry {
   readonly endedAt: string;
   /** "ok" for a resolved run, "failed" for a rejected one. */
   readonly status: "ok" | "failed";
+  /** The structured Outcome the Session self-reported (ADR-0011), or null when
+   *  the phase reports none (impl/planner/merger) or the Session produced no
+   *  parseable Outcome (a failed attempt against the Retry budget). Lets the
+   *  Session browser show pass/give-up/no-outcome at a glance. */
+  readonly outcome: ParsedOutcome | null;
   /** Present only on failed entries: the error message. */
   readonly error?: string;
 }
@@ -309,7 +315,9 @@ interface ManifestEntryArgs {
  * Build a manifest entry for a successfully resolved agent run. Pure and
  * env-free so the field set + nulling rules are unit-testable in isolation.
  */
-export function buildManifestEntry(args: ManifestEntryArgs & { result: RunLike }): ManifestEntry {
+export function buildManifestEntry(
+  args: ManifestEntryArgs & { result: RunLike; outcome?: ParsedOutcome | null }
+): ManifestEntry {
   const session = lastSession(args.result);
   return {
     runId: args.runId,
@@ -323,6 +331,7 @@ export function buildManifestEntry(args: ManifestEntryArgs & { result: RunLike }
     startedAt: args.startedAt.toISOString(),
     endedAt: args.endedAt.toISOString(),
     status: "ok",
+    outcome: args.outcome ?? null,
   };
 }
 
@@ -362,6 +371,7 @@ export function buildFailedManifestEntry(
     startedAt: args.startedAt.toISOString(),
     endedAt: args.endedAt.toISOString(),
     status: "failed",
+    outcome: null,
     error: errorMessage(args.error),
   };
 }

--- a/.sandcastle/observability.test.mts
+++ b/.sandcastle/observability.test.mts
@@ -352,7 +352,33 @@ describe("buildManifestEntry", () => {
       startedAt: "2026-06-28T12:00:00.000Z",
       endedAt: "2026-06-28T12:05:00.000Z",
       status: "ok",
+      outcome: null,
     });
+  });
+
+  it("records the parsed Outcome when one is supplied (ADR-0011)", () => {
+    const entry = buildManifestEntry({
+      runId: "run-x",
+      phase: "rev",
+      issue: 53,
+      branch: "sandcastle/issue-53",
+      result: okResult(),
+      startedAt: new Date(0),
+      endedAt: new Date(0),
+      outcome: { kind: "give-up", reason: "the suite is red" },
+    });
+    expect(entry.outcome).toEqual({ kind: "give-up", reason: "the suite is red" });
+  });
+
+  it("defaults the Outcome to null for phases that report none (impl/planner/merger)", () => {
+    const entry = buildManifestEntry({
+      runId: "run-x",
+      phase: "impl",
+      result: okResult(),
+      startedAt: new Date(0),
+      endedAt: new Date(0),
+    });
+    expect(entry.outcome).toBeNull();
   });
 
   it("nulls missing session fields, nulls issue/branch by default, counts zero commits", () => {
@@ -401,6 +427,7 @@ describe("buildFailedManifestEntry", () => {
       endedAt: "2026-06-28T12:01:00.000Z",
       status: "failed",
       error: "boom",
+      outcome: null,
     });
   });
 

--- a/.sandcastle/prompts.test.mts
+++ b/.sandcastle/prompts.test.mts
@@ -2,15 +2,17 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 /**
- * #65 — give the Reviewer and Merger prompts a durable `ready-for-human`
- * escape hatch so the upcoming persistent poller can't re-dispatch
- * un-actionable work forever (ADR-0006). A persistent loop re-sees the same
- * PR every tick, so every give-up path must durably change GitHub state.
+ * Prompt-contract tests. They read the prompt source directly (no agent run
+ * required), the same way theme.test pins CSS/colour wiring.
  *
- * These tests pin the wording/commands the two prompts must contain (and the
- * ones they must NOT) when an item escalates to `ready-for-human`. They read
- * the prompt source directly (no agent run required), the same way theme.test
- * pins CSS/colour wiring.
+ * - **review-prompt.md** now follows the **Outcome contract** (ADR-0011, #96):
+ *   the Reviewer no longer runs `gh` to flip labels/draft state; it reviews,
+ *   commits fixes (Model A), posts a prose review-summary comment, and ends its
+ *   Session with a structured `<outcome>` tag the orchestrator acts on. These
+ *   tests pin that tag contract and assert the dispatch-controlling `gh`
+ *   commands are gone.
+ * - **merge-prompt.md** still owns its give-up path in the prompt (the Merger →
+ *   Landing move is ADR-0012, a separate issue); its tests are unchanged.
  */
 const reviewPrompt = readFileSync(new URL("./review-prompt.md", import.meta.url), "utf8");
 const mergePrompt = readFileSync(new URL("./merge-prompt.md", import.meta.url), "utf8");
@@ -29,39 +31,38 @@ function topSection(md: string, heading: string): string {
   return next === -1 ? md.slice(start) : md.slice(start, next);
 }
 
-describe("review-prompt.md — ready-for-human give-up path", () => {
-  const giveUp = topSection(reviewPrompt, "GIVE-UP PATH");
-
-  it("exists as its own section", () => {
-    expect(giveUp.length).toBeGreaterThan(0);
+describe("review-prompt.md — Outcome contract (ADR-0011)", () => {
+  it("instructs a pass verdict via the <outcome>pass</outcome> tag", () => {
+    expect(reviewPrompt).toMatch(/<outcome>pass<\/outcome>/);
   });
 
-  it("triggers when the Reviewer cannot make the change pass", () => {
-    expect(giveUp).toMatch(/cannot make the change pass/i);
+  it("instructs a give-up verdict with a one-line reason via the outcome tag", () => {
+    expect(reviewPrompt).toMatch(/<outcome>give-up: .*<\/outcome>/);
   });
 
-  it("posts a COMMENT-type review explaining why", () => {
-    expect(giveUp).toMatch(/gh pr review .* --comment/);
+  it("triggers give-up when the Reviewer cannot make the change pass", () => {
+    expect(reviewPrompt).toMatch(/cannot make the change pass/i);
   });
 
-  it("adds the ready-for-human label to the PR", () => {
-    expect(giveUp).toMatch(/--add-label ready-for-human/);
+  it("still commits fixes itself (Model A)", () => {
+    expect(reviewPrompt).toMatch(/RALPH: Review/);
   });
 
-  it("keeps the PR as a draft", () => {
-    expect(giveUp).toMatch(/draft/i);
+  it("still posts a prose review-summary comment (a comment is not dispatch-controlling)", () => {
+    expect(reviewPrompt).toMatch(/gh pr review .* --comment/);
   });
 
-  it("does not mark the PR ready, add reviewed, or merge", () => {
-    // No positive ready/reviewed/merge instructions in the escalation. Prose
-    // negations ("do not") deliberately avoid the literal command strings.
-    expect(giveUp).not.toMatch(/gh pr ready\b/);
-    expect(giveUp).not.toMatch(/--add-label reviewed/);
-    expect(giveUp).not.toMatch(/gh pr merge/);
+  it("contains no label, draft-flip, or merge commands — the orchestrator owns those (ADR-0011)", () => {
+    expect(reviewPrompt).not.toMatch(/--add-label/);
+    expect(reviewPrompt).not.toMatch(/--remove-label/);
+    expect(reviewPrompt).not.toMatch(/gh label create/);
+    expect(reviewPrompt).not.toMatch(/gh pr ready/);
+    expect(reviewPrompt).not.toMatch(/gh pr merge/);
   });
 
-  it("uses the CONTEXT.md ready-for-human semantics", () => {
-    expect(giveUp).toMatch(/out of all Dispatch buckets; a human owns it/i);
+  it("does not tell the agent to touch the reviewed / ready-for-human labels", () => {
+    expect(reviewPrompt).not.toMatch(/ready-for-human/);
+    expect(reviewPrompt).not.toMatch(/`reviewed`/);
   });
 });
 

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -61,66 +61,41 @@ If you find improvements to make:
 
 If the code is already clean and well-structured, make no commits.
 
-# GIVE-UP PATH — ESCALATE TO ready-for-human
+# REPORT YOUR OUTCOME
 
-If you **cannot make the change pass** — `pnpm typecheck` or `pnpm test` is red and,
-after your fix attempts, you cannot get it green (a defect, a missing dependency,
-or an architectural problem beyond a review-level fix) — do **not** open the
-REVIEW GATE below. A persistent poller would otherwise re-dispatch this draft PR
-to the Reviewer every tick. Instead, hand the PR to a human via the universal
-terminal label — `ready-for-human`, meaning "out of all Dispatch buckets; a human
-owns it":
+Your job is **review + comment + verdict**. You do **not** change any
+dispatch-controlling GitHub state — the orchestrator adds/removes labels, flips
+the PR draft/ready, and merges, acting on the Outcome you report here. Do not run
+any `gh` command that adds or removes a label, marks the PR ready, or merges it.
 
-1. Post a `COMMENT`-type review explaining what you found and why the change will
-   not pass:
-
-   ```
-   gh pr review {{BRANCH}} --comment --body "<what is blocking the change>"
-   ```
-
-2. Add the `ready-for-human` label to the PR:
-
-   ```
-   gh label create ready-for-human --description "Out of all Dispatch buckets; a human owns it" --color 0052CC || true
-   gh pr edit {{BRANCH}} --add-label ready-for-human
-   ```
-
-3. **Leave the PR as a draft** — do not mark it ready for review, and do not add
-   the `reviewed` label. An escalated PR is never marked ready or merged.
-
-Once escalated, output <promise>COMPLETE</promise> and stop.
-
-# REVIEW GATE
-
-Follow this gate **only** if the change passes (green) or was already clean. If
-you could not make it pass, you followed the GIVE-UP PATH above instead — stop
-here.
-
-The Implementer opened this branch's PR as a **draft**. Once you are done reviewing
-(whether or not you committed fixes) and the change is green, open the gate so the
-Merger can land it:
-
-1. Post a `COMMENT`-type review summarizing your assessment (GitHub forbids approving
-   your own PR, so this is a comment, not an approval):
+1. Post a `COMMENT`-type review summarizing your assessment (prose — a comment is
+   not dispatch-controlling; GitHub also forbids approving your own PR, so this is
+   a comment, not an approval):
 
    ```
    gh pr review {{BRANCH}} --comment --body "<your review summary>"
    ```
 
-2. Ensure the `reviewed` label exists, creating it if it does not, then add it to the PR:
+2. End your Session with **exactly one** structured Outcome tag on its own line:
+   - The change is green — `pnpm typecheck` and `pnpm test` pass, whether you
+     committed fixes or it was already clean:
 
-   ```
-   gh label create reviewed --description "Reviewed by the Sandcastle Reviewer" --color 0E8A16 || true
-   gh pr edit {{BRANCH}} --add-label reviewed
-   ```
+     ```
+     <outcome>pass</outcome>
+     ```
 
-3. Flip the PR from draft to ready for review:
+   - You **cannot make the change pass** — `pnpm typecheck` or `pnpm test` is red
+     and, after your fix attempts, you cannot get it green (a defect, a missing
+     dependency, or an architectural problem beyond a review-level fix):
 
-   ```
-   gh pr ready {{BRANCH}}
-   ```
+     ```
+     <outcome>give-up: <one-line reason></outcome>
+     ```
 
-Only a PR that is **ready (not draft) and labeled `reviewed`** will be merged; leaving
-any of these steps undone keeps the PR open for a human.
+The orchestrator parses this tag and performs the transition: `pass` opens the
+review gate (marks the PR reviewed and ready for the Merger); `give-up` hands the
+PR to a human and leaves it a draft. If you emit no parseable tag, no state
+changes and the review is retried.
 
-Once complete, output <promise>COMPLETE</promise>.
+Once you have posted the comment and emitted the Outcome tag, output
+<promise>COMPLETE</promise>.


### PR DESCRIPTION
Closes #96. First slice of **ADR-0011**: the Reviewer stops mutating dispatch-controlling GitHub state from prompt instructions and instead reports a structured **Outcome** the orchestrator parses and acts on. The agent judges; orchestrator code mutates.

## What changed (`.sandcastle/`)

- **`dispatch.mts`** — new pure, unit-tested logic over an injectable `gh` runner:
  - `parseOutcome(text)` → `pass` / `give-up:reason` / `null`, parsed like the Planner's `<plan>` block (last tag wins; garbled/missing → `null`).
  - `handleReviewerOutcome(outcome, pr, gh)` — **pass**: ensure `reviewed` → add it → flip PR draft→ready; **give-up**: add `ready-for-human` **before any other state change** (crash-safe), then post the reason, PR left draft.
  - `reviewerGiveUpComment(reason)` pins the `ready-for-human` semantics in code; extracted an `ensureLabel` best-effort helper de-duping the label-create blocks (also applied to `handleImplementerOutcome`).
- **`observability.mts`** — `ManifestEntry` gains `outcome`; `recordedRun` takes an outcome extractor so the Reviewer entry records the parsed Outcome (`null` otherwise, including no-parseable-Outcome).
- **`events.mts`** — `reviewer-outcome` (pass/give-up/none) + `review-transition` (gate/give-up) events through the single rendering seam (prose / ndjson / log / severity / tag map / emitter).
- **`review-prompt.md`** — deleted the REVIEW GATE + give-up `gh` label/draft/`gh pr ready`/merge commands; now instructs review + fixes (Model A) + prose comment + `<outcome>` tag.
- **`main.mts`** — `dispatchReviewer` parses the Outcome, emits the outcome event, applies the transition only when one parsed (`null` → no GitHub mutation), emits the transition event, and records the Outcome in the Manifest.

## Acceptance criteria

- [x] Reviewer prompt has no label / draft-flip / `gh pr ready` commands; instructs work + comment + Outcome tag
- [x] Orchestrator performs gate + give-up transitions from the parsed Outcome; logic pure + unit-tested with an injectable `gh` runner
- [x] Give-up applies `ready-for-human` before any other state change
- [x] A Session with no parseable Outcome → no GitHub mutation, recorded as such in the Manifest, emits an event
- [x] Prompt test pins the Outcome-tag contract instead of `gh` command wording
- [x] Manifest entry includes the parsed Outcome
- [x] `pnpm typecheck` and `pnpm test` green (479 passed); `pnpm lint` clean

## Notes / scope

- The **merge-prompt** and its give-up path are intentionally untouched — the Merger→Landing move is ADR-0012, a separate issue.
- The Retry budget for no-parseable-Outcome / crashes is a follow-up (the no-Outcome signal is emitted + recorded here for it to consume).
- Known residual (per ADR): the **pass gate** is an inherent two-write transition whose intermediate state sits in no bucket, so an orchestrator crash mid-gate can strand a PR; only the give-up path is made fully crash-safe by this slice. A reconciler is the ADR's later defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)