### PR TITLE
#100 Origin-tracking: fetch per Poll tick; fork, validate, and prune against origin/main (ADR-0013)

### DIFF
--- a/.sandcastle/dispatch.mts
+++ b/.sandcastle/dispatch.mts
@@ -20,6 +20,76 @@ export const POOL_SIZE = 10;
 export const POLL_INTERVAL_MS = 60_000;
 
 /**
+ * The single ref the orchestrator bases everything on (CONTEXT.md; ADR-0013).
+ * New issue branches fork from it, the Landing validates against it, and Prune's
+ * merged-reachability gate uses it — never local `main` or `HEAD`. Local `main`
+ * and the working tree stay purely the human's business; a `git fetch origin`
+ * each Poll tick keeps this remote-tracking ref fresh without touching them.
+ */
+export const BASE_BRANCH = "origin/main";
+
+/** The install+build hook every sandbox runs before its work. Frozen-lockfile
+ *  because this repo is pnpm-only — a plain install would resolve a competing
+ *  lockfile (see main.mts). */
+const INSTALL_BUILD = "pnpm install --frozen-lockfile && pnpm build";
+
+/**
+ * The subset of `sandcastle.createSandbox` options the orchestrator computes per
+ * dispatch: which `branch` to work on, the `baseBranch` it forks from, the
+ * `node_modules` carry-over, and the `onSandboxReady` hook commands. The live
+ * `sandbox` factory (docker) is supplied by `main.mts` and spread alongside —
+ * kept out of here so the fork-base decision (ADR-0013) is pure and testable.
+ */
+export interface SandboxSpec {
+  readonly branch: string;
+  readonly baseBranch: string;
+  readonly copyToWorktree: string[];
+  readonly hooks: { sandbox: { onSandboxReady: { command: string }[] } };
+}
+
+/**
+ * Build the sandbox spec for an Implementer: fork the new `sandcastle/issue-N`
+ * branch from {@link BASE_BRANCH} (`origin/main`), NEVER `HEAD`. Sandcastle's
+ * docker provider defaults `baseBranch` to `HEAD`, so an explicit base is what
+ * makes the fork independent of whatever the human has checked out (ADR-0013,
+ * #100). Then install + build the worktree before the agent runs.
+ */
+export function implementerSandboxSpec(branch: string): SandboxSpec {
+  return {
+    branch,
+    baseBranch: BASE_BRANCH,
+    copyToWorktree: ["node_modules"],
+    hooks: { sandbox: { onSandboxReady: [{ command: INSTALL_BUILD }] } },
+  };
+}
+
+/**
+ * Build the sandbox spec for a Landing (CONTEXT.md: Landing; ADR-0012/0013): a
+ * throwaway `sandcastle/merge-N` worktree forked from {@link BASE_BRANCH}
+ * (`origin/main`) — the same base the PR will land on server-side, so a green
+ * validation is meaningful — never local `main`, which falls behind after every
+ * server-side merge. `onSandboxReady` install+builds, then deterministically
+ * test-merges the PR branch: `git merge <prBranch>` (a textual conflict) or
+ * `pnpm typecheck && pnpm test` (a red suite) exiting non-zero rejects
+ * `createSandbox` and routes `main.mts` to the failure escalation.
+ */
+export function landingSandboxSpec(issue: number, prBranch: string): SandboxSpec {
+  return {
+    branch: `sandcastle/merge-${issue}`,
+    baseBranch: BASE_BRANCH,
+    copyToWorktree: ["node_modules"],
+    hooks: {
+      sandbox: {
+        onSandboxReady: [
+          { command: INSTALL_BUILD },
+          { command: `git merge ${prBranch} --no-edit && pnpm typecheck && pnpm test` },
+        ],
+      },
+    },
+  };
+}
+
+/**
  * The shared concurrency **Pool** (CONTEXT.md: Pool). A single limiter of size
  * `POOL_SIZE`; `acquire()` reserves a slot (resolving immediately if one is
  * free, otherwise queueing until a slot is released) and `release()` frees one.

--- a/.sandcastle/dispatch.test.mts
+++ b/.sandcastle/dispatch.test.mts
@@ -2,10 +2,13 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import {
+  BASE_BRANCH,
   NOOP_IMPLEMENTER_COMMENT,
   POOL_SIZE,
   POLL_INTERVAL_MS,
   createInflight,
+  implementerSandboxSpec,
+  landingSandboxSpec,
   createPool,
   filterReadyForAgent,
   filterReadyForMerge,
@@ -841,7 +844,74 @@ describe("resolvePlanEmit", () => {
 
 // ---- main.mts structural guards (read source, never import — it runs the loop) --
 
+describe("implementerSandboxSpec — fork the issue branch from origin/main (ADR-0013, #100)", () => {
+  it("bases the new sandcastle/issue-N branch on origin/main, never HEAD", () => {
+    // The whole point of ADR-0013: the Implementer forks from origin/main
+    // regardless of what the human has checked out in the host worktree.
+    const spec = implementerSandboxSpec("sandcastle/issue-42");
+    expect(spec.branch).toBe("sandcastle/issue-42");
+    expect(spec.baseBranch).toBe("origin/main");
+    expect(spec.baseBranch).toBe(BASE_BRANCH);
+  });
+
+  it("installs + builds the worktree before the agent runs", () => {
+    const spec = implementerSandboxSpec("sandcastle/issue-7");
+    const commands = spec.hooks.sandbox.onSandboxReady.map((h) => h.command);
+    expect(commands).toContain("pnpm install --frozen-lockfile && pnpm build");
+  });
+});
+
+describe("landingSandboxSpec — validate the merge against origin/main (ADR-0013, #100)", () => {
+  it("forks the throwaway merge worktree from origin/main", () => {
+    // Validation base = landing base: the Landing tests the merge against the
+    // same ref it will actually land on server-side (origin/main), not stale
+    // local main.
+    const spec = landingSandboxSpec(88, "sandcastle/issue-88");
+    expect(spec.branch).toBe("sandcastle/merge-88");
+    expect(spec.baseBranch).toBe("origin/main");
+    expect(spec.baseBranch).toBe(BASE_BRANCH);
+  });
+
+  it("test-merges the PR branch then runs typecheck + test", () => {
+    const spec = landingSandboxSpec(88, "sandcastle/issue-88");
+    const commands = spec.hooks.sandbox.onSandboxReady.map((h) => h.command);
+    expect(commands).toContain("pnpm install --frozen-lockfile && pnpm build");
+    expect(commands).toContain(
+      "git merge sandcastle/issue-88 --no-edit && pnpm typecheck && pnpm test"
+    );
+  });
+});
+
 const mainSource = readFileSync(new URL("./main.mts", import.meta.url), "utf8");
+
+describe("main.mts — origin-tracking (ADR-0013, #100)", () => {
+  it("fetches origin before querying buckets on a dispatching tick", () => {
+    // Each Poll tick that will dispatch fetches origin first so everything bases
+    // on a fresh origin/main; the fetch call precedes the bucket queries.
+    const fetchIdx = mainSource.indexOf("fetchOrigin(");
+    const queryIdx = mainSource.indexOf("queryReadyForAgent()");
+    expect(fetchIdx).toBeGreaterThan(-1);
+    expect(queryIdx).toBeGreaterThan(-1);
+    expect(fetchIdx).toBeLessThan(queryIdx);
+  });
+
+  it("git fetch origin never touches local main or the working tree", () => {
+    // A bare `git fetch origin` updates remote-tracking refs only — no pull, no
+    // checkout, no merge into local main (ADR-0013).
+    expect(mainSource).toMatch(/"fetch",\s*"origin"/);
+    expect(mainSource).not.toMatch(/"pull"/);
+  });
+
+  it("skips the tick's dispatch and emits fetchFailed when the fetch fails", () => {
+    // A fetch failure must NOT proceed on stale refs — it events and skips.
+    expect(mainSource).toMatch(/events\.fetchFailed\(/);
+  });
+
+  it("forks the Implementer branch from origin/main via implementerSandboxSpec", () => {
+    const impl = mainSource.slice(mainSource.indexOf("async function dispatchImplementer"));
+    expect(impl).toMatch(/implementerSandboxSpec\(issue\.branch\)/);
+  });
+});
 
 describe("main.mts — persistent shared-pool orchestrator (ADR-0006)", () => {
   it("drops the discrete MAX_ITERATIONS for-loop", () => {
@@ -978,19 +1048,15 @@ describe("main.mts — deterministic Landing (ADR-0012, #97)", () => {
     expect(landing).toMatch(/pool\.release\(\)/);
   });
 
-  it("validates in an ISOLATED worktree forked from main, never head mode", () => {
-    // createSandbox with an explicit throwaway branch + baseBranch main forks an
-    // isolated worktree, so the Landing never touches the host's live main/worktree.
+  it("validates in an ISOLATED worktree forked from origin/main via landingSandboxSpec", () => {
+    // The fork base (origin/main, ADR-0013) + the deterministic test-then-merge
+    // validation now live in the pure `landingSandboxSpec` (unit-tested above);
+    // the driver just spreads it into createSandbox. Basing on origin/main (never
+    // stale local `main`) keeps the Landing off the host's live main/worktree.
     const landing = mainSource.slice(mainSource.indexOf("async function dispatchLanding"));
     expect(landing).toMatch(/createSandbox/);
-    expect(landing).toMatch(/branch:\s*`sandcastle\/merge-\$\{pr\.issue\}`/);
-    expect(landing).toMatch(/baseBranch:\s*"main"/);
-  });
-
-  it("runs the deterministic test-then-merge validation (git merge → typecheck → test)", () => {
-    const landing = mainSource.slice(mainSource.indexOf("async function dispatchLanding"));
-    expect(landing).toMatch(/git merge \$\{pr\.branch\}/);
-    expect(landing).toMatch(/pnpm typecheck && pnpm test/);
+    expect(landing).toMatch(/landingSandboxSpec\(pr\.issue, pr\.branch\)/);
+    expect(landing).not.toMatch(/baseBranch:\s*"main"/);
   });
 
   it("lands a clean+green PR server-side with gh pr merge --merge", () => {

--- a/.sandcastle/events.mts
+++ b/.sandcastle/events.mts
@@ -122,6 +122,13 @@ interface GhErrorEvent extends BaseEvent {
   readonly error: string;
 }
 
+/** The per-tick `git fetch origin` failed (ADR-0013): the tick's dispatch is
+ *  skipped rather than proceeding on stale refs; the next tick re-fetches. */
+interface FetchFailedEvent extends BaseEvent {
+  readonly type: "fetch-failed";
+  readonly error: string;
+}
+
 /** A dispatched Session (Implementer/Reviewer) resolved. `ok` carries the
  *  commit count; `failed` carries the error string. This is the structured
  *  resolution signal for the Cockpit — headless prose only renders the failure
@@ -201,6 +208,7 @@ export type OrchestratorEvent =
   | PlannerFailedEvent
   | NoopEscalatedEvent
   | GhErrorEvent
+  | FetchFailedEvent
   | SessionResolvedEvent
   | ReviewerOutcomeEvent
   | ReviewTransitionEvent
@@ -247,6 +255,8 @@ export function formatEventProse(event: OrchestratorEvent): string | null {
       return `  ⚠ #${event.issue} produced no commits — escalated to ready-for-human.`;
     case "gh-error":
       return `  ⚠ gh ${event.args.join(" ")} failed: ${event.error}`;
+    case "fetch-failed":
+      return `  ✗ git fetch origin failed: ${event.error} — skipping dispatch this tick.`;
     case "session-resolved":
       if (event.status === "ok") return null;
       return `  ✗ ${roleFailedPrefix(event.role)}#${event.issue} (${event.branch}) failed: ${event.error}`;
@@ -308,6 +318,7 @@ function roleFailedPrefix(role: OrchestratorRole): string {
 export function eventStream(event: OrchestratorEvent): EventStream {
   switch (event.type) {
     case "gh-error":
+    case "fetch-failed":
     case "planner-no-plan":
     case "planner-failed":
     case "landing-failed":
@@ -362,6 +373,8 @@ export function formatEventLog(event: OrchestratorEvent): string {
       return `⚠ #${event.issue} no commits · escalated to ready-for-human`;
     case "gh-error":
       return `⚠ gh ${event.args.join(" ")} failed · ${event.error}`;
+    case "fetch-failed":
+      return `✗ git fetch origin failed · ${event.error} · dispatch skipped`;
     case "reviewer-outcome":
       if (event.outcome === "give-up")
         return `⚠ rev #${event.issue} outcome · give-up · ${event.reason}`;
@@ -399,6 +412,7 @@ export type EventSeverity = "failure" | "warn" | "normal";
 export function eventSeverity(event: OrchestratorEvent): EventSeverity {
   switch (event.type) {
     case "gh-error":
+    case "fetch-failed":
     case "planner-failed":
     case "landing-failed":
       return "failure";
@@ -448,6 +462,7 @@ const EVENT_TYPE_TAGS: Record<OrchestratorEvent["type"], true> = {
   "planner-failed": true,
   "noop-escalated": true,
   "gh-error": true,
+  "fetch-failed": true,
   "session-resolved": true,
   "reviewer-outcome": true,
   "review-transition": true,
@@ -537,6 +552,9 @@ export interface OrchestratorEvents {
   noopEscalated(issue: number): void;
   /** A per-tick `gh` query failed (tolerated; next tick re-queries). */
   ghError(args: ReadonlyArray<string>, error: string): void;
+  /** The per-tick `git fetch origin` failed — the tick's dispatch is skipped
+   *  rather than proceeding on stale refs (ADR-0013). */
+  fetchFailed(error: string): void;
   /** The Reviewer's parsed Outcome (ADR-0011): `pass` / `give-up` (with
    *  `reason`) / `none` when no parseable Outcome tag was produced. */
   reviewerOutcome(issue: number, outcome: "pass" | "give-up" | "none", reason: string | null): void;
@@ -615,6 +633,7 @@ export function createEvents(opts: CreateEventsOptions = {}): OrchestratorEvents
       }),
     noopEscalated: (issue) => emit({ type: "noop-escalated", issue, ts: stamp() }),
     ghError: (args, error) => emit({ type: "gh-error", args, error, ts: stamp() }),
+    fetchFailed: (error) => emit({ type: "fetch-failed", error, ts: stamp() }),
     reviewerOutcome: (issue, outcome, reason) =>
       emit({ type: "reviewer-outcome", issue, outcome, reason, ts: stamp() }),
     reviewTransition: (issue, transition) =>

--- a/.sandcastle/events.test.mts
+++ b/.sandcastle/events.test.mts
@@ -150,6 +150,12 @@ describe("formatEventProse", () => {
     ).toBe("  ⚠ gh pr list --state open failed: nope");
   });
 
+  it("reproduces the fetch-failed line (dispatch skipped this tick)", () => {
+    expect(formatEventProse(evt({ type: "fetch-failed", error: "network down" }))).toBe(
+      "  ✗ git fetch origin failed: network down — skipping dispatch this tick."
+    );
+  });
+
   it("renders the parsed Reviewer Outcome (pass / give-up / none)", () => {
     expect(
       formatEventProse(evt({ type: "reviewer-outcome", issue: 7, outcome: "pass", reason: null }))
@@ -288,6 +294,7 @@ describe("eventStream", () => {
 
   it("routes the error-shaped events to stderr", () => {
     expect(eventStream(evt({ type: "gh-error", args: ["a"], error: "x" }))).toBe("stderr");
+    expect(eventStream(evt({ type: "fetch-failed", error: "x" }))).toBe("stderr");
     expect(eventStream(evt({ type: "planner-no-plan" }))).toBe("stderr");
     expect(eventStream(evt({ type: "planner-failed", error: "x" }))).toBe("stderr");
     expect(
@@ -418,6 +425,17 @@ describe("createEvents", () => {
     expect(err).toHaveBeenCalledTimes(2);
     expect(err).toHaveBeenNthCalledWith(1, "Planner failed: boom");
     expect(err).toHaveBeenNthCalledWith(2, "  ⚠ gh pr list failed: nope");
+  });
+
+  it("in prose mode routes a fetch failure to stderr", () => {
+    const out = vi.fn();
+    const err = vi.fn();
+    const events = createEvents({ format: "prose", out, err });
+    events.fetchFailed("network down");
+    expect(out).not.toHaveBeenCalled();
+    expect(err).toHaveBeenCalledWith(
+      "  ✗ git fetch origin failed: network down — skipping dispatch this tick."
+    );
   });
 
   it("in prose mode does not write anything for a successful session-resolved", () => {
@@ -582,6 +600,7 @@ describe("EVENT_TYPES / isKnownEventType", () => {
     "planner-failed",
     "noop-escalated",
     "gh-error",
+    "fetch-failed",
     "session-resolved",
     "reviewer-outcome",
     "review-transition",
@@ -607,6 +626,7 @@ describe("eventSeverity", () => {
   it("classifies failures as failure", () => {
     expect(eventSeverity(evt({ type: "gh-error", args: ["a"], error: "x" }))).toBe("failure");
     expect(eventSeverity(evt({ type: "planner-failed", error: "x" }))).toBe("failure");
+    expect(eventSeverity(evt({ type: "fetch-failed", error: "x" }))).toBe("failure");
     expect(
       eventSeverity(
         evt({

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -11,7 +11,9 @@ import {
   handleImplementerOutcome,
   handleLandingFailure,
   handleReviewerOutcome,
+  implementerSandboxSpec,
   issueFromBranch,
+  landingSandboxSpec,
   parseOutcome,
   pickImplementers,
   pickPrs,
@@ -132,6 +134,23 @@ async function recordedRun<R extends RunLike>(args: {
 async function gh(args: string[]): Promise<string> {
   const { stdout } = await execFileAsync("gh", args, { maxBuffer: 10 * 1024 * 1024 });
   return stdout;
+}
+
+/**
+ * Fetch `origin` on the host once per dispatching Poll tick (ADR-0013). A bare
+ * `git fetch origin` updates the remote-tracking refs (`origin/main`, …) ONLY —
+ * it never pulls, checks out, or merges into the human's local `main` or working
+ * tree, so origin-tracking stays entirely off the human's refs. Returns
+ * ok/error so the loop can skip this tick's dispatch on failure rather than
+ * fork, validate, and prune against stale refs; the next tick re-fetches.
+ */
+async function fetchOrigin(): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    await execFileAsync("git", ["fetch", "origin"], { maxBuffer: 10 * 1024 * 1024 });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) };
+  }
 }
 
 /**
@@ -290,19 +309,15 @@ async function dispatchImplementer(issue: {
   const implLC = lifecycle(implLabel);
   implLC.start();
   try {
+    // Fork the new sandcastle/issue-N branch from origin/main (never HEAD), then
+    // install+build. The fork base + hooks are the pure `implementerSandboxSpec`
+    // (ADR-0013): basing on origin/main makes the Implementer independent of what
+    // the human has checked out in the host worktree. --frozen-lockfile because
+    // this repo is pnpm-only, so a plain `npm install` would resolve a competing
+    // lockfile (see implementerSandboxSpec / INSTALL_BUILD in dispatch.mts).
     await using sandbox = await sandcastle.createSandbox({
       sandbox: dockerSandbox(),
-      branch: issue.branch,
-      copyToWorktree: ["node_modules"],
-      hooks: {
-        sandbox: {
-          // pnpm with a frozen lockfile: this repo is pnpm-only (pnpm-lock.yaml,
-          // no package-lock.json), so `npm install` would generate a competing
-          // lockfile and resolve deps differently. --frozen-lockfile keeps sandbox
-          // installs reproducible and fast against the committed pnpm-lock.yaml.
-          onSandboxReady: [{ command: "pnpm install --frozen-lockfile && pnpm build" }],
-        },
-      },
+      ...implementerSandboxSpec(issue.branch),
     });
     implLC.sandbox();
 
@@ -491,33 +506,23 @@ async function dispatchLanding(pr: {
   const startedAt = new Date();
   events.landingStarted(pr.prNumber, pr.issue, pr.branch);
   try {
-    // Validate in an ISOLATED worktree forked from `main`, NOT head mode. A
+    // Validate in an ISOLATED worktree forked from `origin/main`, NOT head mode. A
     // bind-mount provider (docker) defaults to the "head" strategy, which
     // bind-mounts the host repo directly — so the validation `git merge <PR
     // branch>` would mutate your real local `main` and dirty the host working
-    // tree. Passing an explicit `branch` (with `baseBranch: main`) forks a
-    // throwaway `sandcastle/merge-<issue>` worktree from `main`: the local
-    // test-merge happens there and is discarded when the worktree is disposed,
-    // while the actual landing stays server-side via `gh pr merge`. So the
-    // Landing never reads or mutates the host's live `main` or working tree.
+    // tree. `landingSandboxSpec` passes an explicit throwaway
+    // `sandcastle/merge-<issue>` branch forked from `origin/main` (ADR-0013): the
+    // local test-merge happens there against the SAME base the PR lands on
+    // server-side (not stale local `main`), and is discarded when the worktree is
+    // disposed, while the actual landing stays server-side via `gh pr merge`. So
+    // the Landing never reads or mutates the host's live `main` or working tree.
     // (Leftover local `sandcastle/merge-*` refs are cleaned by `pnpm
-    // sandcastle:prune`.)
+    // sandcastle:prune`.) The deterministic test-then-merge hooks live in the
+    // spec: a textual conflict or a red suite rejects createSandbox and routes us
+    // to the failure escalation below.
     await using sandbox = await sandcastle.createSandbox({
       sandbox: dockerSandbox(),
-      branch: `sandcastle/merge-${pr.issue}`,
-      baseBranch: "main",
-      copyToWorktree: ["node_modules"],
-      hooks: {
-        sandbox: {
-          onSandboxReady: [
-            { command: "pnpm install --frozen-lockfile && pnpm build" },
-            // Deterministic test-then-merge validation. Either step exiting
-            // non-zero (a textual conflict, or a red suite) rejects createSandbox
-            // and routes us to the failure escalation below.
-            { command: `git merge ${pr.branch} --no-edit && pnpm typecheck && pnpm test` },
-          ],
-        },
-      },
+      ...landingSandboxSpec(pr.issue, pr.branch),
     });
     lc.sandbox();
 
@@ -611,81 +616,91 @@ for (;;) {
   if (!shouldQueryBuckets(free)) {
     events.poolFull();
   } else {
-    // One ready-for-agent issue query + one PR query feeds all three buckets:
-    // the PR list is split into ready-for-merge / ready-for-review, and its
-    // issue set excludes ready-for-agent issues that already have an open PR.
-    const [readyForAgent, prs] = await Promise.all([queryReadyForAgent(), queryReviewMergePrs()]);
-    const openPrIssues = new Set(prs.map((p) => p.issue));
-    const readyForMerge = filterReadyForMerge(prs, inflight);
-    const readyForReview = filterReadyForReview(prs, inflight);
-    const actionable = filterReadyForAgent(readyForAgent, inflight, openPrIssues);
-
-    events.buckets(
-      readyForMerge.length,
-      readyForReview.length,
-      readyForAgent.length,
-      actionable.length
-    );
-
-    // Priority drain (ADR-0006): fill `free` slots merge → review → implement,
-    // so started work lands before new work starts (prevents PR starvation).
-    // `remaining` counts slots still free after each bucket drains its share.
-    let remaining = free;
-
-    // 1) ready-for-merge — ready + reviewed PRs → one agent-free Landing per PR.
-    const landings = pickPrs(readyForMerge, remaining, inflight);
-    for (const pr of landings) {
-      inflight.add(pr.issue);
-      // The Landing emits its own started/landed/failed events (agent-free, not a
-      // dispatch/session-resolved Session) — see dispatchLanding.
-      void dispatchLanding(pr); // fire-and-forget; resolves across ticks.
-    }
-    remaining -= landings.length;
-
-    // 2) ready-for-review — draft sandcastle/issue-N PRs without reviewed.
-    const reviewers = pickPrs(readyForReview, remaining, inflight);
-    for (const pr of reviewers) {
-      inflight.add(pr.issue);
-      events.dispatchReviewer(pr.prNumber, pr.issue, pr.branch);
-      void dispatchReviewer(pr);
-    }
-    remaining -= reviewers.length;
-
-    // 3) ready-for-agent — the implement stage runs ONLY when actionable issues
-    // exist AND a slot remains after merge+review draining (don't spend a slot
-    // on work we can't start). The Plan cache (ADR-0010) skips the Opus Planner
-    // while the RAW ready-for-agent set is unchanged: `resolvePlanEmit` keys on
-    // `readyForAgent` (the pre-filter query result, NOT `actionable` — else the
-    // cache goes stale when a blocker merges out), reuses the cached emit on a
-    // hit, and re-invokes the Planner only on a miss. Either way the pure
-    // dispatch below runs over the emit, so a capped emit still drains on later
-    // ticks (no starvation). `pickImplementers` caps at `remaining`.
-    if (shouldRunPlanner(actionable, remaining)) {
-      try {
-        const resolved = await resolvePlanEmit(readyForAgent, planCache, runPlanner);
-        planCache = resolved.cache;
-        if (resolved.plannerRan) {
-          events.plannerEmitted(resolved.emit.length);
-        } else {
-          events.planReused(resolved.emit.length);
-        }
-
-        // The Planner re-queries gh, so it can emit an issue that just got a PR
-        // this tick — drop those before dispatching. (In-flight dedupe + the
-        // remaining-slot cap happen in pickImplementers.)
-        const dispatchable = resolved.emit.filter((i) => !openPrIssues.has(i.number));
-        const toDispatch = pickImplementers(dispatchable, remaining, inflight);
-
-        for (const issue of toDispatch) {
-          inflight.add(issue.number);
-          events.dispatchImplementer(issue.number, issue.title, issue.branch);
-          void dispatchImplementer(issue);
-        }
-      } catch (err) {
-        events.plannerFailed(errorMessage(err));
-      }
+    // ADR-0013: fetch origin once per dispatching tick so new branches fork,
+    // Landings validate, and Prune gates against a fresh origin/main. A fetch
+    // failure skips THIS tick's dispatch rather than proceeding on stale refs —
+    // the next tick re-fetches. (Bare fetch: remote-tracking refs only, never the
+    // human's local main or working tree.)
+    const fetched = await fetchOrigin();
+    if (!fetched.ok) {
+      events.fetchFailed(fetched.error);
     } else {
-      events.plannerSkipped();
+      // One ready-for-agent issue query + one PR query feeds all three buckets:
+      // the PR list is split into ready-for-merge / ready-for-review, and its
+      // issue set excludes ready-for-agent issues that already have an open PR.
+      const [readyForAgent, prs] = await Promise.all([queryReadyForAgent(), queryReviewMergePrs()]);
+      const openPrIssues = new Set(prs.map((p) => p.issue));
+      const readyForMerge = filterReadyForMerge(prs, inflight);
+      const readyForReview = filterReadyForReview(prs, inflight);
+      const actionable = filterReadyForAgent(readyForAgent, inflight, openPrIssues);
+
+      events.buckets(
+        readyForMerge.length,
+        readyForReview.length,
+        readyForAgent.length,
+        actionable.length
+      );
+
+      // Priority drain (ADR-0006): fill `free` slots merge → review → implement,
+      // so started work lands before new work starts (prevents PR starvation).
+      // `remaining` counts slots still free after each bucket drains its share.
+      let remaining = free;
+
+      // 1) ready-for-merge — ready + reviewed PRs → one agent-free Landing per PR.
+      const landings = pickPrs(readyForMerge, remaining, inflight);
+      for (const pr of landings) {
+        inflight.add(pr.issue);
+        // The Landing emits its own started/landed/failed events (agent-free, not a
+        // dispatch/session-resolved Session) — see dispatchLanding.
+        void dispatchLanding(pr); // fire-and-forget; resolves across ticks.
+      }
+      remaining -= landings.length;
+
+      // 2) ready-for-review — draft sandcastle/issue-N PRs without reviewed.
+      const reviewers = pickPrs(readyForReview, remaining, inflight);
+      for (const pr of reviewers) {
+        inflight.add(pr.issue);
+        events.dispatchReviewer(pr.prNumber, pr.issue, pr.branch);
+        void dispatchReviewer(pr);
+      }
+      remaining -= reviewers.length;
+
+      // 3) ready-for-agent — the implement stage runs ONLY when actionable issues
+      // exist AND a slot remains after merge+review draining (don't spend a slot
+      // on work we can't start). The Plan cache (ADR-0010) skips the Opus Planner
+      // while the RAW ready-for-agent set is unchanged: `resolvePlanEmit` keys on
+      // `readyForAgent` (the pre-filter query result, NOT `actionable` — else the
+      // cache goes stale when a blocker merges out), reuses the cached emit on a
+      // hit, and re-invokes the Planner only on a miss. Either way the pure
+      // dispatch below runs over the emit, so a capped emit still drains on later
+      // ticks (no starvation). `pickImplementers` caps at `remaining`.
+      if (shouldRunPlanner(actionable, remaining)) {
+        try {
+          const resolved = await resolvePlanEmit(readyForAgent, planCache, runPlanner);
+          planCache = resolved.cache;
+          if (resolved.plannerRan) {
+            events.plannerEmitted(resolved.emit.length);
+          } else {
+            events.planReused(resolved.emit.length);
+          }
+
+          // The Planner re-queries gh, so it can emit an issue that just got a PR
+          // this tick — drop those before dispatching. (In-flight dedupe + the
+          // remaining-slot cap happen in pickImplementers.)
+          const dispatchable = resolved.emit.filter((i) => !openPrIssues.has(i.number));
+          const toDispatch = pickImplementers(dispatchable, remaining, inflight);
+
+          for (const issue of toDispatch) {
+            inflight.add(issue.number);
+            events.dispatchImplementer(issue.number, issue.title, issue.branch);
+            void dispatchImplementer(issue);
+          }
+        } catch (err) {
+          events.plannerFailed(errorMessage(err));
+        }
+      } else {
+        events.plannerSkipped();
+      }
     }
   }
 

--- a/.sandcastle/prune-driver.mts
+++ b/.sandcastle/prune-driver.mts
@@ -81,10 +81,12 @@ export function discoverPruneState(cwd?: string): PruneState {
       .filter((b) => b.length > 0)
   );
 
-  // Reachability-gated `sandcastle/*` branches. Scope (`sandcastle/*`) is applied
-  // here; the Merger-scratch exclusion is applied inside `planPrune`.
+  // Reachability-gated `sandcastle/*` branches. The gate is `origin/main`, NOT
+  // local `main` (ADR-0013): after a server-side `gh pr merge` local `main` falls
+  // behind, so gating on it would miss branches that already landed. Scope
+  // (`sandcastle/*`) is applied here; the Merger-scratch exclusion is in `planPrune`.
   const mergedBranches = new Set(
-    git(["branch", "--merged", "main", "--format=%(refname:short)"], cwd)
+    git(["branch", "--merged", "origin/main", "--format=%(refname:short)"], cwd)
       .split("\n")
       .map((b) => b.trim())
       .filter((b) => b.startsWith("sandcastle/"))

--- a/.sandcastle/prune-plan.mts
+++ b/.sandcastle/prune-plan.mts
@@ -37,9 +37,10 @@ export interface PruneState {
   runLogs: string[];
   /** All worktrees from `git worktree list`, each tagged with its dirty flag. */
   worktrees: WorktreeState[];
-  /** `git branch --merged main` filtered to `sandcastle/*` (reachability-gated,
-   *  ADR-0004). May include Merger scratch; `planPrune` moves those into the
-   *  Merger bucket so they are never double-counted. */
+  /** `git branch --merged origin/main` filtered to `sandcastle/*` (reachability-
+   *  gated on origin, not stale local `main` — ADR-0013/0004). May include Merger
+   *  scratch; `planPrune` moves those into the Merger bucket so they are never
+   *  double-counted. */
   mergedBranches: Set<string>;
   /** `sandcastle/merge-*` scratch branches left by the Merger's ISOLATED
    *  test-merge — force-deleted, NOT gated on `--merged main` (their merge

--- a/.sandcastle/prune.mts
+++ b/.sandcastle/prune.mts
@@ -7,13 +7,13 @@
  *                   Display output (glossary: "Run log"). Safe to delete.
  *   2. Worktrees  — `.sandcastle/worktrees/<wt>` whose branch is merged into main.
  *                   Throwaway sandboxes; removed only once their work has landed.
- *   3. Branches   — local `sandcastle/*` branches merged into `main`.
+ *   3. Branches   — local `sandcastle/*` branches merged into `origin/main`.
  *   4. Merger scratch — leftover `sandcastle/merge-*` branches (and any lingering
  *                   worktree) left by the Merger's ISOLATED test-merge
  *                   (branchStrategy "branch" in main.mts). Their merge commit's
  *                   content already lands on main via `gh pr merge`, but the
  *                   branch tip is never reachable from main — so unlike (3) they
- *                   are force-deleted (`-D`), not gated on `--merged main`. Still
+ *                   are force-deleted (`-D`), not gated on `--merged origin/main`. Still
  *                   `sandcastle/*`-scoped and worktree-safe (dirty ones skipped).
  *
  *   NOT pruned: Transcripts (`.sandcastle/sessions/**.jsonl`) and the Manifest.
@@ -30,9 +30,11 @@
  * it (ADR-0009); only the printing below is CLI-specific.
  *
  * Design decisions (see ADR-0004):
- *   - "merged" means reachable from `main` (`git branch --merged main`). This
- *     preserves branches whose PRs were intentionally left open for a human
- *     (ADR-0003), since their tips are NOT yet on main.
+ *   - "merged" means reachable from `origin/main` (`git branch --merged
+ *     origin/main`), not stale local `main` — after a server-side `gh pr merge`
+ *     local `main` falls behind, so gating on it would miss landed branches
+ *     (ADR-0013). This still preserves branches whose PRs were intentionally left
+ *     open for a human (ADR-0003), since their tips are NOT yet on origin/main.
  *   - Scope is `sandcastle/*` only — never `main` or hand-made branches.
  *   - Local only — remote branches are left to GitHub's delete-on-merge.
  *   - Dry-run by default. Pass `--force` (or `--yes`) to actually delete.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,7 +19,7 @@ Sandcastle's existing human-readable Display output under `.sandcastle/logs/*.lo
 _Avoid_: transcript.
 
 **Prune**:
-The `pnpm sandcastle:prune` maintenance command (`.sandcastle/prune.mts`) that reclaims throwaway state after Runs: deletes Run logs, removes merged worktrees, and deletes local `sandcastle/*` branches merged into `main`. Dry-run by default; `--force` to apply. Never touches Transcripts or the Manifest — the audit trail is out of scope by design (ADR-0004).
+The `pnpm sandcastle:prune` maintenance command (`.sandcastle/prune.mts`) that reclaims throwaway state after Runs: deletes Run logs, removes merged worktrees, and deletes local `sandcastle/*` branches merged into `origin/main` (the reachability gate is origin, not stale local `main` — ADR-0013). Dry-run by default; `--force` to apply. Never touches Transcripts or the Manifest — the audit trail is out of scope by design (ADR-0004).
 _Avoid_: clean, gc.
 
 **Session**:


### PR DESCRIPTION
Closes #100.

The pipeline silently depended on the human keeping the host checkout fresh (ADR-0013). This makes the orchestrator track `origin/main` instead of local refs.

## Changes

- **Fetch per tick.** Each dispatching Poll tick runs a bare `git fetch origin` (remote-tracking refs only — never local `main` or the working tree). A fetch failure emits a new `fetch-failed` event and **skips that tick's dispatch** rather than proceeding on stale refs; the next tick re-fetches.
- **Implementer forks from `origin/main`.** New `sandcastle/issue-N` branches fork from `origin/main`, never `HEAD`, via the pure `implementerSandboxSpec` — independent of whatever the human has checked out.
- **Landing validates against `origin/main`.** `landingSandboxSpec` forks the throwaway `sandcastle/merge-N` worktree from `origin/main` (the same base it lands on server-side) and carries the deterministic test-then-merge hooks.
- **Prune gate uses `origin/main`.** `git branch --merged main` → `--merged origin/main`, so a landed branch is pruned even when local `main` is behind.

The fork-base decision is extracted into pure, unit-tested builders in `dispatch.mts`; driver wiring is asserted against `main.mts` source, matching the module's existing test conventions.

## Acceptance criteria

- [x] Each Poll tick fetches origin before dispatching; a fetch failure is evented and skips the tick's dispatch
- [x] A newly created issue branch is based on `origin/main` regardless of the host checkout (covered by a test)
- [x] Landing validation uses `origin/main` as the base
- [x] Prune's merged gate uses `origin/main`; a merged branch is pruned even when local `main` is behind
- [x] The orchestrator never mutates local `main` or the host working tree (bare fetch + isolated worktrees; a test asserts no `pull`)
- [x] `pnpm typecheck` and `pnpm test` green (499 tests pass)

**Out of scope:** the "Conflict resolver uses `origin/main`" line is moot — the resolver isn't dispatched yet (documented follow-up); its future spec inherits `BASE_BRANCH`. Self-restart (the other half of ADR-0013) is not in #100's ACs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)