### PR TITLE
#98 Retry budget: bound deterministic failures at N=3 per issue+phase (ADR-0011)

### DIFF
--- a/.sandcastle/cockpit-core.test.mts
+++ b/.sandcastle/cockpit-core.test.mts
@@ -302,6 +302,15 @@ describe("formatEventLog", () => {
       formatEventLog(evt({ type: "review-transition", issue: 7, transition: "give-up" }))
     ).toBe("→ #7 escalated to ready-for-human");
   });
+
+  it("renders the Retry-budget attempt-failed and budget-exhausted log lines (#98)", () => {
+    expect(
+      formatEventLog(evt({ type: "attempt-failed", issue: 7, phase: "land", attempt: 2, limit: 3 }))
+    ).toBe("⚠ #7 land attempt 2/3 failed");
+    expect(
+      formatEventLog(evt({ type: "budget-exhausted", issue: 7, phase: "land", attempts: 3 }))
+    ).toBe("⚠ #7 land budget exhausted · 3 attempts · escalated to ready-for-human");
+  });
 });
 
 // ── appendLogLine: bounded ring buffer for the scrolling log ─────────────────

--- a/.sandcastle/dispatch.mts
+++ b/.sandcastle/dispatch.mts
@@ -157,6 +157,56 @@ export function createInflight(): Inflight {
   };
 }
 
+// ---- The Retry budget (ADR-0011, #98) -------------------------------------
+
+/**
+ * The per-issue-per-phase allowance of failed attempts before escalation
+ * (CONTEXT.md: Retry budget). `N=3` is one attempt plus two retries: on the 3rd
+ * failed attempt for the same issue+phase the orchestrator escalates the item to
+ * `ready-for-human`.
+ */
+export const RETRY_BUDGET_N = 3;
+
+/** Has an issue+phase reached the {@link RETRY_BUDGET_N} threshold? Pure so the
+ *  threshold decision is unit-testable apart from the mutable counter. */
+export function isBudgetExhausted(count: number): boolean {
+  return count >= RETRY_BUDGET_N;
+}
+
+/**
+ * The **Retry budget** (CONTEXT.md): the orchestrator's in-memory counter of
+ * failed attempts keyed by issue+phase, living beside the In-flight set and Plan
+ * cache (same non-durability philosophy, ADR-0006/0010). A failed attempt — a
+ * crashed Session, one that resolved without a parseable Outcome, or a failed
+ * Landing — is `fail(issue, phase)`; a successful Session (or an escalation)
+ * `clear(issue, phase)`s it. Not durable: a restart forgets counts, which at
+ * worst grants extra attempts — benign under at-least-once dispatch.
+ */
+export interface RetryBudget {
+  /** Record one failed attempt for `issue`+`phase`; returns the new count. */
+  fail(issue: number, phase: string): number;
+  /** Reset the counter for `issue`+`phase` (a successful Session or escalation). */
+  clear(issue: number, phase: string): void;
+  /** The current failed-attempt count for `issue`+`phase` (0 if none). */
+  count(issue: number, phase: string): number;
+}
+
+/** Create an empty Retry budget. Keyed by a `issue:phase` string so the same
+ *  issue is counted independently across its impl / rev / land / resolve phases. */
+export function createRetryBudget(): RetryBudget {
+  const counts = new Map<string, number>();
+  const key = (issue: number, phase: string) => `${issue}:${phase}`;
+  return {
+    fail: (issue, phase) => {
+      const next = (counts.get(key(issue, phase)) ?? 0) + 1;
+      counts.set(key(issue, phase), next);
+      return next;
+    },
+    clear: (issue, phase) => void counts.delete(key(issue, phase)),
+    count: (issue, phase) => counts.get(key(issue, phase)) ?? 0,
+  };
+}
+
 /**
  * A `ready-for-agent` issue as the Dispatch bucket sees it: its number, title,
  * current labels (so an issue that ALSO carries `ready-for-human` can be
@@ -492,7 +542,7 @@ export type ParsedOutcome =
  * tolerated. Returns `null` for a missing OR garbled verdict (anything that is
  * not exactly `pass` or `give-up: <non-empty reason>`) — a null is NOT a
  * give-up: it triggers no GitHub mutation and is recorded as a failed attempt
- * against the (future) Retry budget, so one formatting lapse never escalates
+ * against the Retry budget, so one formatting lapse never escalates
  * automatable work to a human (ADR-0011).
  *
  * Pure and side-effect-free so the contract is unit-testable in isolation.
@@ -580,52 +630,87 @@ export async function handleReviewerOutcome(
   return "give-up";
 }
 
+// ---- Retry-budget escalation (ADR-0011, #98) ------------------------------
+
 /**
- * Comment body the orchestrator posts when a Landing fails (ADR-0012, #97).
- * Carries the failure output (a textual `git merge` conflict, or the red
- * `pnpm typecheck && pnpm test` output) plus the CONTEXT.md `ready-for-human`
- * semantics — pins the wording that used to live in the merge prompt's GIVE-UP
- * PATH, now owned by orchestrator code. Exported so it is documented and
- * unit-testable.
+ * The GitHub-shape of the item whose Retry budget is being escalated. The
+ * budget bounds every pooled phase, but the escalation differs by shape (issue
+ * §198's blocked-by "both shapes"):
+ *
+ * - **issue** (implement phase) — the issue is still labeled `ready-for-agent`;
+ *   escalation adds `ready-for-human` and strips `ready-for-agent`, like the
+ *   no-op Implementer path.
+ * - **pr** (review / resolve / land) — a `sandcastle/issue-N` PR; escalation adds
+ *   `ready-for-human` via the ADR-0011 crash-safe transition runner. `gated`
+ *   distinguishes the two PR states: a review/resolve PR is a plain draft
+ *   (`gated: false`, leave it), while a land-phase PR is ready + `reviewed`
+ *   (`gated: true`, strip the gate — remove `reviewed`, revert to draft).
  */
-export function landingFailureComment(failure: string): string {
+export type BudgetTarget =
+  | { readonly kind: "issue"; readonly issue: number }
+  | { readonly kind: "pr"; readonly prNumber: number; readonly gated: boolean };
+
+/**
+ * Comment body the orchestrator posts when an item exhausts its Retry budget
+ * (CONTEXT.md: Retry budget; ADR-0011). Cites the phase and attempt count — the
+ * signal a human needs to see why automatable work was handed over — plus the
+ * CONTEXT.md `ready-for-human` semantics and the note that re-labeling grants a
+ * fresh budget. An optional `detail` (the last failure's one-line output) is
+ * appended so the PR/issue still shows what went wrong. Exported so the wording
+ * is documented and unit-testable.
+ */
+export function budgetExhaustedComment(phase: string, attempts: number, detail?: string): string {
+  const tail = detail ? `\n\nLast failure:\n\n${detail}` : "";
   return (
-    `Sandcastle Landing could not land this PR:\n\n${failure}\n\n` +
-    "Escalating to `ready-for-human` (out of all Dispatch buckets; a human owns it). " +
-    "The `reviewed` label is removed and the PR reverted to draft — it is never merged from here."
+    `Sandcastle exhausted its Retry budget for the \`${phase}\` phase after ${attempts} ` +
+    "failed attempts (a crashed Session, a Session with no parseable Outcome, or a failed " +
+    "Landing). Escalating to `ready-for-human` (out of all Dispatch buckets; a human owns " +
+    "it). Re-labeling the item for the agent grants a fresh budget." +
+    tail
   );
 }
 
 /**
- * Failed-Landing terminal handling (CONTEXT.md: Landing, ready-for-human;
- * ADR-0012, #97). A Landing — the agent-free merge phase — that hits a textual
- * conflict or a red suite escalates the ready + `reviewed` PR to a human. Pure
- * logic over an injectable {@link GhRunner}, the same PR-shaped transition
- * runner shape as {@link handleReviewerOutcome}, so every step is unit-testable.
+ * Escalate a Retry-budget-exhausted item to `ready-for-human` (CONTEXT.md: Retry
+ * budget, ready-for-human; ADR-0011, #98). Shape-aware over {@link BudgetTarget}
+ * and crash-safe like the other terminal handlers — the terminal label lands
+ * FIRST, so no crash point strands the item outside every Dispatch bucket:
  *
- * Crash-safe ordering (ADR-0011): defensively ensure `ready-for-human` exists,
- * **add the terminal label FIRST**, then strip the bucket state (remove
- * `reviewed`, revert the PR ready → draft), then post the failure output as a
- * comment. Applying the terminal label before removing `reviewed`/ready means
- * no crash point leaves the PR ready-without-`reviewed` in no Dispatch bucket.
+ * - **issue** — ensure `ready-for-human`, add it, then strip `ready-for-agent`,
+ *   then comment (the issue-shaped implement escalation).
+ * - **pr** — ensure `ready-for-human`, add it, then (only when `gated`, a land
+ *   PR) remove `reviewed` and revert ready → draft, then comment. A review/resolve
+ *   PR (`gated: false`) is already a plain draft, so its bucket state is untouched.
  *
- * (This slice escalates every failed Landing straight to a human; a follow-up
- * replaces this with the Conflict resolver dispatch, and the Retry budget makes
- * failed Landings spend attempts — ADR-0012.)
+ * Pure logic over an injectable {@link GhRunner}, so every step is unit-testable.
  */
-export async function handleLandingFailure(
-  pr: { readonly prNumber: number },
-  failure: string,
-  gh: GhRunner
+export async function escalateBudgetExhausted(
+  target: BudgetTarget,
+  phase: string,
+  attempts: number,
+  gh: GhRunner,
+  detail?: string
 ): Promise<void> {
-  const n = String(pr.prNumber);
+  const body = budgetExhaustedComment(phase, attempts, detail);
   await ensureLabel(gh, READY_FOR_HUMAN);
-  // Terminal label FIRST (crash-safe), then remove the ready-for-merge bucket
-  // state so a persistent poller stops re-dispatching this ready + reviewed PR.
+  if (target.kind === "issue") {
+    const n = String(target.issue);
+    // Terminal label FIRST (crash-safe), then strip the ready-for-agent bucket.
+    await gh.run(["issue", "edit", n, "--add-label", "ready-for-human"]);
+    await gh.run(["issue", "edit", n, "--remove-label", "ready-for-agent"]);
+    await gh.run(["issue", "comment", n, "--body", body]);
+    return;
+  }
+
+  const n = String(target.prNumber);
   await gh.run(["pr", "edit", n, "--add-label", "ready-for-human"]);
-  await gh.run(["pr", "edit", n, "--remove-label", "reviewed"]);
-  await gh.run(["pr", "ready", n, "--undo"]);
-  await gh.run(["pr", "comment", n, "--body", landingFailureComment(failure)]);
+  if (target.gated) {
+    // A land-phase PR is ready + reviewed — strip the review gate so a persistent
+    // poller stops re-dispatching it from the ready-for-merge bucket.
+    await gh.run(["pr", "edit", n, "--remove-label", "reviewed"]);
+    await gh.run(["pr", "ready", n, "--undo"]);
+  }
+  await gh.run(["pr", "comment", n, "--body", body]);
 }
 
 /**

--- a/.sandcastle/dispatch.test.mts
+++ b/.sandcastle/dispatch.test.mts
@@ -6,7 +6,12 @@ import {
   NOOP_IMPLEMENTER_COMMENT,
   POOL_SIZE,
   POLL_INTERVAL_MS,
+  RETRY_BUDGET_N,
+  budgetExhaustedComment,
   createInflight,
+  createRetryBudget,
+  escalateBudgetExhausted,
+  isBudgetExhausted,
   implementerSandboxSpec,
   landingSandboxSpec,
   createPool,
@@ -14,10 +19,8 @@ import {
   filterReadyForMerge,
   filterReadyForReview,
   handleImplementerOutcome,
-  handleLandingFailure,
   handleReviewerOutcome,
   issueFromBranch,
-  landingFailureComment,
   parseOutcome,
   pickImplementers,
   pickPrs,
@@ -68,6 +71,157 @@ function mockGh(throwOnCreate = false): GhRunner & { calls: string[][] } {
   };
   return Object.assign(gh, { calls });
 }
+
+// ---- #98 — the Retry budget (ADR-0011) ------------------------------------
+//
+// An in-memory counter keyed by issue+phase, living beside the In-flight set and
+// Plan cache (same non-durability philosophy). A failed attempt — a crashed
+// Session, a Session with no parseable Outcome, or a failed Landing — increments
+// it; a successful Session clears it. On the N=3rd failed attempt for an
+// issue+phase the orchestrator escalates the item to `ready-for-human` and clears
+// the counter, so a human who re-labels the item gets a fresh budget.
+
+describe("createRetryBudget", () => {
+  it("counts failed attempts per issue+phase, starting from zero", () => {
+    const budget = createRetryBudget();
+    expect(budget.count(42, "impl")).toBe(0);
+    expect(budget.fail(42, "impl")).toBe(1);
+    expect(budget.fail(42, "impl")).toBe(2);
+    expect(budget.count(42, "impl")).toBe(2);
+  });
+
+  it("keeps issue+phase counters independent", () => {
+    const budget = createRetryBudget();
+    budget.fail(42, "impl");
+    budget.fail(42, "rev"); // same issue, different phase
+    budget.fail(7, "impl"); // different issue, same phase
+    expect(budget.count(42, "impl")).toBe(1);
+    expect(budget.count(42, "rev")).toBe(1);
+    expect(budget.count(7, "impl")).toBe(1);
+    // the Conflict-resolver phase is just another phase string — no special-casing
+    expect(budget.count(42, "resolve")).toBe(0);
+  });
+
+  it("clears a counter on a successful Session (fresh budget after)", () => {
+    const budget = createRetryBudget();
+    budget.fail(42, "impl");
+    budget.fail(42, "impl");
+    budget.clear(42, "impl");
+    expect(budget.count(42, "impl")).toBe(0);
+    expect(budget.fail(42, "impl")).toBe(1); // counting resumes from zero
+  });
+
+  it("reaches the threshold on the N=3rd failed attempt", () => {
+    const budget = createRetryBudget();
+    expect(isBudgetExhausted(budget.fail(42, "impl"))).toBe(false); // 1
+    expect(isBudgetExhausted(budget.fail(42, "impl"))).toBe(false); // 2
+    expect(isBudgetExhausted(budget.fail(42, "impl"))).toBe(true); //  3 → escalate
+  });
+});
+
+describe("isBudgetExhausted", () => {
+  it("pins N=3 (one attempt plus two retries)", () => {
+    expect(RETRY_BUDGET_N).toBe(3);
+    expect(isBudgetExhausted(2)).toBe(false);
+    expect(isBudgetExhausted(3)).toBe(true);
+    expect(isBudgetExhausted(4)).toBe(true);
+  });
+});
+
+describe("budgetExhaustedComment", () => {
+  it("cites the phase and attempt count with the ready-for-human semantics", () => {
+    const body = budgetExhaustedComment("rev", 3);
+    expect(body).toMatch(/rev/);
+    expect(body).toMatch(/3/);
+    expect(body).toMatch(/out of all Dispatch buckets; a human owns it/i);
+  });
+
+  it("appends the last-failure detail when given one", () => {
+    const body = budgetExhaustedComment("land", 3, "CONFLICT in app/page.tsx");
+    expect(body).toContain("CONFLICT in app/page.tsx");
+  });
+});
+
+describe("escalateBudgetExhausted", () => {
+  it("issue shape (implement): adds ready-for-human, strips ready-for-agent, comments", async () => {
+    const gh = mockGh();
+    await escalateBudgetExhausted({ kind: "issue", issue: 42 }, "impl", 3, gh);
+    const calls = gh.calls.map((c) => c.join(" "));
+    expect(calls.some((s) => /issue edit 42 --add-label ready-for-human/.test(s))).toBe(true);
+    expect(calls.some((s) => /issue edit 42 --remove-label ready-for-agent/.test(s))).toBe(true);
+    expect(calls.some((s) => /issue comment 42 --body/.test(s))).toBe(true);
+  });
+
+  it("issue shape: adds ready-for-human BEFORE stripping ready-for-agent (crash-safe)", async () => {
+    const gh = mockGh();
+    await escalateBudgetExhausted({ kind: "issue", issue: 42 }, "impl", 3, gh);
+    const addIdx = gh.calls.findIndex((c) => c.includes("--add-label"));
+    const removeIdx = gh.calls.findIndex((c) => c.includes("--remove-label"));
+    expect(addIdx).toBeGreaterThan(-1);
+    expect(addIdx).toBeLessThan(removeIdx);
+  });
+
+  it("pr-draft shape (review/resolve): adds ready-for-human + comments, leaves the draft alone", async () => {
+    const gh = mockGh();
+    await escalateBudgetExhausted({ kind: "pr", prNumber: 7, gated: false }, "rev", 3, gh);
+    const calls = gh.calls.map((c) => c.join(" "));
+    expect(calls.some((s) => /pr edit 7 --add-label ready-for-human/.test(s))).toBe(true);
+    expect(calls.some((s) => /pr comment 7 --body/.test(s))).toBe(true);
+    // a draft PR under review carries no reviewed label and is not ready — don't touch either
+    expect(calls.some((s) => /--remove-label reviewed/.test(s))).toBe(false);
+    expect(calls.some((s) => /pr ready 7/.test(s))).toBe(false);
+  });
+
+  it("pr-gated shape (land): strips the review gate (reviewed + ready) then comments", async () => {
+    const gh = mockGh();
+    await escalateBudgetExhausted({ kind: "pr", prNumber: 7, gated: true }, "land", 3, gh);
+    const calls = gh.calls.map((c) => c.join(" "));
+    expect(calls.some((s) => /pr edit 7 --add-label ready-for-human/.test(s))).toBe(true);
+    expect(calls.some((s) => /pr edit 7 --remove-label reviewed/.test(s))).toBe(true);
+    expect(calls.some((s) => /pr ready 7 --undo/.test(s))).toBe(true);
+    expect(calls.some((s) => /pr comment 7 --body/.test(s))).toBe(true);
+    // the PR is NEVER merged from the exhaustion path
+    expect(calls.some((s) => /pr merge/.test(s))).toBe(false);
+  });
+
+  it("pr-gated shape: applies ready-for-human BEFORE it strips reviewed / reverts to draft (crash-safe)", async () => {
+    const gh = mockGh();
+    await escalateBudgetExhausted({ kind: "pr", prNumber: 7, gated: true }, "land", 3, gh);
+    const addIdx = gh.calls.findIndex((c) => c.includes("--add-label"));
+    const removeIdx = gh.calls.findIndex((c) => c.includes("--remove-label"));
+    const readyIdx = gh.calls.findIndex((c) => c[0] === "pr" && c[1] === "ready");
+    expect(addIdx).toBeGreaterThan(-1);
+    expect(addIdx).toBeLessThan(removeIdx);
+    expect(addIdx).toBeLessThan(readyIdx);
+  });
+
+  it("creates the ready-for-human label defensively and tolerates 'already exists'", async () => {
+    const gh = mockGh(true); // the label create throws
+    await escalateBudgetExhausted({ kind: "issue", issue: 42 }, "impl", 3, gh);
+    expect(
+      gh.calls.some((c) => c[0] === "label" && c[1] === "create" && c[2] === "ready-for-human")
+    ).toBe(true);
+    // best-effort create must not abort the escalation
+    const calls = gh.calls.map((c) => c.join(" "));
+    expect(calls.some((s) => /issue edit 42 --add-label ready-for-human/.test(s))).toBe(true);
+  });
+
+  it("posts the attempt-citing comment (with any detail)", async () => {
+    const gh = mockGh();
+    await escalateBudgetExhausted(
+      { kind: "pr", prNumber: 7, gated: true },
+      "land",
+      3,
+      gh,
+      "red suite"
+    );
+    const comment = gh.calls.find((c) => c[1] === "comment")!;
+    const body = comment[comment.length - 1];
+    expect(body).toMatch(/3/);
+    expect(body).toContain("red suite");
+    expect(body).toMatch(/out of all Dispatch buckets; a human owns it/i);
+  });
+});
 
 describe("constants", () => {
   it("pins the shared Pool size to 10 (ADR-0006)", () => {
@@ -319,7 +473,7 @@ describe("handleImplementerOutcome", () => {
 // parses (like the Planner's <plan> block) and acts on. `parseOutcome` is the
 // pure parser; `handleReviewerOutcome` is the pure transition logic over an
 // injectable gh runner. A garbled / missing tag parses to `null` — no GitHub
-// mutation, the Session is a failed attempt against the (future) Retry budget.
+// mutation, the Session is a failed attempt against the Retry budget (#98).
 
 describe("parseOutcome", () => {
   it("parses a pass verdict", () => {
@@ -432,69 +586,6 @@ describe("reviewerGiveUpComment", () => {
   it("includes the reason and the CONTEXT.md ready-for-human semantics", () => {
     const body = reviewerGiveUpComment("missing dependency");
     expect(body).toContain("missing dependency");
-    expect(body).toMatch(/out of all Dispatch buckets; a human owns it/i);
-  });
-});
-
-// ---- #97 — failed-Landing terminal handling (ADR-0012) --------------------
-//
-// A Landing (the agent-free merge phase) that hits a textual conflict or a red
-// suite escalates the ready + `reviewed` PR to `ready-for-human` via the same
-// crash-safe PR-shaped transition runner the Reviewer give-up uses (ADR-0011):
-// the terminal label is applied BEFORE the bucket state (`reviewed` / ready) is
-// removed, so no crash point strands the PR outside every Dispatch bucket.
-
-describe("handleLandingFailure", () => {
-  const failure = "CONFLICT (content): merge conflict in app/page.tsx";
-
-  it("escalates to ready-for-human: strips reviewed, reverts to draft, posts the failure", async () => {
-    const gh = mockGh();
-    await handleLandingFailure({ prNumber: 7 }, failure, gh);
-    const calls = gh.calls.map((c) => c.join(" "));
-    expect(calls.some((s) => /pr edit 7 --add-label ready-for-human/.test(s))).toBe(true);
-    expect(calls.some((s) => /pr edit 7 --remove-label reviewed/.test(s))).toBe(true);
-    expect(calls.some((s) => /pr ready 7 --undo/.test(s))).toBe(true);
-    expect(calls.some((s) => /pr comment 7 --body/.test(s))).toBe(true);
-    // the PR is NEVER merged from the failure path
-    expect(calls.some((s) => /pr merge/.test(s))).toBe(false);
-  });
-
-  it("applies ready-for-human BEFORE it removes reviewed / reverts to draft (crash-safe)", async () => {
-    const gh = mockGh();
-    await handleLandingFailure({ prNumber: 7 }, failure, gh);
-    const addIdx = gh.calls.findIndex((c) => c.includes("--add-label"));
-    const removeIdx = gh.calls.findIndex((c) => c.includes("--remove-label"));
-    const undoIdx = gh.calls.findIndex((c) => c[0] === "pr" && c[1] === "ready");
-    expect(addIdx).toBeGreaterThan(-1);
-    expect(addIdx).toBeLessThan(removeIdx);
-    expect(addIdx).toBeLessThan(undoIdx);
-  });
-
-  it("creates the ready-for-human label defensively and tolerates 'already exists'", async () => {
-    const gh = mockGh(true); // the label create throws
-    await handleLandingFailure({ prNumber: 7 }, failure, gh);
-    expect(
-      gh.calls.some((c) => c[0] === "label" && c[1] === "create" && c[2] === "ready-for-human")
-    ).toBe(true);
-    // best-effort create must not abort the escalation
-    const calls = gh.calls.map((c) => c.join(" "));
-    expect(calls.some((s) => /pr edit 7 --add-label ready-for-human/.test(s))).toBe(true);
-  });
-
-  it("posts the failure output with the ready-for-human semantics", async () => {
-    const gh = mockGh();
-    await handleLandingFailure({ prNumber: 7 }, failure, gh);
-    const comment = gh.calls.find((c) => c[1] === "comment")!;
-    const body = comment[comment.length - 1];
-    expect(body).toContain(failure);
-    expect(body).toMatch(/out of all Dispatch buckets; a human owns it/i);
-  });
-});
-
-describe("landingFailureComment", () => {
-  it("includes the failure output and the CONTEXT.md ready-for-human semantics", () => {
-    const body = landingFailureComment("pnpm test — 3 failing");
-    expect(body).toContain("pnpm test — 3 failing");
     expect(body).toMatch(/out of all Dispatch buckets; a human owns it/i);
   });
 });
@@ -1064,9 +1155,14 @@ describe("main.mts — deterministic Landing (ADR-0012, #97)", () => {
     expect(landing).toMatch(/gh\(\["pr", "merge", String\(pr\.prNumber\), "--merge"\]\)/);
   });
 
-  it("escalates a failed Landing to ready-for-human via handleLandingFailure", () => {
+  it("spends a Retry-budget attempt on a failed Landing (no immediate escalation)", () => {
+    // #98: a failed Landing no longer escalates on the first failure — it spends a
+    // budget attempt (gated PR shape) and only escalates on exhaustion.
     const landing = mainSource.slice(mainSource.indexOf("async function dispatchLanding"));
-    expect(landing).toMatch(/handleLandingFailure\(/);
+    expect(landing).toMatch(/recordFailedAttempt\(/);
+    expect(landing).not.toMatch(/handleLandingFailure/);
+    expect(landing).toMatch(/kind:\s*"pr"[\s\S]*?gated:\s*true/);
+    expect(landing).toMatch(/"land"/);
   });
 
   it("emits the Landing Live-feed events (started, landed, failed)", () => {
@@ -1081,5 +1177,56 @@ describe("main.mts — deterministic Landing (ADR-0012, #97)", () => {
     expect(landing).toMatch(/generateRunId\(pr\.issue\)/);
     expect(landing).toMatch(/phase:\s*"land"/);
     expect(landing).toMatch(/result:\s*agentFreeResult/);
+  });
+});
+
+describe("main.mts — Retry budget (ADR-0011, #98)", () => {
+  it("holds one in-memory Retry budget beside the In-flight set and Plan cache", () => {
+    expect(mainSource).toMatch(/createRetryBudget\(\)/);
+    expect(mainSource).toMatch(/const budget = createRetryBudget\(\)/);
+  });
+
+  it("escalates on exhaustion via the pure isBudgetExhausted + escalateBudgetExhausted helpers", () => {
+    // The threshold + shape-aware escalation are the unit-tested pure functions;
+    // main.mts only wires them (and clears the counter on escalation).
+    expect(mainSource).toMatch(/isBudgetExhausted\(/);
+    expect(mainSource).toMatch(/escalateBudgetExhausted\(/);
+    expect(mainSource).toMatch(/budget\.clear\(/);
+  });
+
+  it("emits attempt-failed below the threshold and budget-exhausted on escalation", () => {
+    expect(mainSource).toMatch(/events\.attemptFailed\(/);
+    expect(mainSource).toMatch(/events\.budgetExhausted\(/);
+  });
+
+  it("a crashed Implementer spends an issue-shaped attempt; a success clears the impl counter", () => {
+    const impl = mainSource.slice(
+      mainSource.indexOf("async function dispatchImplementer"),
+      mainSource.indexOf("async function dispatchReviewer")
+    );
+    expect(impl).toMatch(/recordFailedAttempt\(\s*\{\s*kind:\s*"issue"/);
+    expect(impl).toMatch(/budget\.clear\([^,]+,\s*"impl"\)/);
+  });
+
+  it("a crashed OR no-Outcome Reviewer spends a PR-shaped attempt; a parsed Outcome clears it", () => {
+    const rev = mainSource.slice(
+      mainSource.indexOf("async function dispatchReviewer"),
+      mainSource.indexOf("async function dispatchLanding")
+    );
+    // both the catch (crash) and the null-Outcome branch record an attempt
+    expect(rev.match(/recordFailedAttempt\(/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+    expect(rev).toMatch(/budget\.clear\([^,]+,\s*"rev"\)/);
+    // review-phase PR is a plain draft → gated:false (leave the draft alone)
+    expect(rev).toMatch(/kind:\s*"pr"[\s\S]*?gated:\s*false/);
+  });
+
+  it("clears the counter on the Nth attempt so a re-labeled item gets a fresh budget", () => {
+    // recordFailedAttempt clears BEFORE escalating (a human re-labeling starts fresh).
+    const helper = mainSource.slice(mainSource.indexOf("function recordFailedAttempt"));
+    const clearIdx = helper.indexOf("budget.clear");
+    const escalateIdx = helper.indexOf("escalateBudgetExhausted");
+    expect(clearIdx).toBeGreaterThan(-1);
+    expect(escalateIdx).toBeGreaterThan(-1);
+    expect(clearIdx).toBeLessThan(escalateIdx);
   });
 });

--- a/.sandcastle/events.mts
+++ b/.sandcastle/events.mts
@@ -192,6 +192,28 @@ interface LandingFailedEvent extends BaseEvent {
   readonly reason: string;
 }
 
+/** A Retry-budget attempt failed below the threshold (ADR-0011, #98): a crashed
+ *  Session, a Session with no parseable Outcome, or a failed Landing. `attempt`
+ *  of `limit` (N=3) — no GitHub state changed, the item stays in its bucket for
+ *  re-dispatch. Makes a struggling item visible before it escalates. */
+interface AttemptFailedEvent extends BaseEvent {
+  readonly type: "attempt-failed";
+  readonly issue: number;
+  readonly phase: string;
+  readonly attempt: number;
+  readonly limit: number;
+}
+
+/** A Retry budget was exhausted (ADR-0011, #98): the Nth failed attempt for an
+ *  issue+phase, so the orchestrator escalated the item to `ready-for-human` and
+ *  cleared the counter. `attempts` is the count cited in the escalation comment. */
+interface BudgetExhaustedEvent extends BaseEvent {
+  readonly type: "budget-exhausted";
+  readonly issue: number;
+  readonly phase: string;
+  readonly attempts: number;
+}
+
 /**
  * The discriminated union of every orchestrator event. `type` is the single
  * discriminator the renderers switch on; the contract the Cockpit consumes.
@@ -214,7 +236,9 @@ export type OrchestratorEvent =
   | ReviewTransitionEvent
   | LandingStartedEvent
   | LandingLandedEvent
-  | LandingFailedEvent;
+  | LandingFailedEvent
+  | AttemptFailedEvent
+  | BudgetExhaustedEvent;
 
 /** Which stdout stream a prose-rendered event belongs on (preserves the
  *  existing stdout/stderr split so headless output is unchanged). */
@@ -275,6 +299,10 @@ export function formatEventProse(event: OrchestratorEvent): string | null {
       return `  ✓ landed PR #${event.pr} (issue #${event.issue}).`;
     case "landing-failed":
       return `  ✗ Landing PR #${event.pr} (issue #${event.issue}) failed: ${event.reason}`;
+    case "attempt-failed":
+      return `  ⚠ #${event.issue} ${event.phase} attempt ${event.attempt}/${event.limit} failed — retrying.`;
+    case "budget-exhausted":
+      return `  ⚠ #${event.issue} ${event.phase} Retry budget exhausted after ${event.attempts} attempts — escalated to ready-for-human.`;
   }
 }
 
@@ -390,6 +418,10 @@ export function formatEventLog(event: OrchestratorEvent): string {
       return `✓ landed PR #${event.pr} (#${event.issue})`;
     case "landing-failed":
       return `✗ landing PR #${event.pr} (#${event.issue}) failed · ${event.reason}`;
+    case "attempt-failed":
+      return `⚠ #${event.issue} ${event.phase} attempt ${event.attempt}/${event.limit} failed`;
+    case "budget-exhausted":
+      return `⚠ #${event.issue} ${event.phase} budget exhausted · ${event.attempts} attempts · escalated to ready-for-human`;
     default: {
       // Exhaustiveness guard: adding a new OrchestratorEvent type without a log
       // line here is a compile error, so the Live log can never silently omit one.
@@ -420,6 +452,8 @@ export function eventSeverity(event: OrchestratorEvent): EventSeverity {
       return event.status === "failed" ? "failure" : "normal";
     case "noop-escalated":
     case "planner-no-plan":
+    case "attempt-failed":
+    case "budget-exhausted":
       return "warn";
     case "reviewer-outcome":
       // A give-up or no-parseable-Outcome is a soft escalation (warn); a pass is
@@ -469,6 +503,8 @@ const EVENT_TYPE_TAGS: Record<OrchestratorEvent["type"], true> = {
   "landing-started": true,
   "landing-landed": true,
   "landing-failed": true,
+  "attempt-failed": true,
+  "budget-exhausted": true,
 };
 
 /** Every `type` discriminator the orchestrator can emit, derived from the union
@@ -561,6 +597,12 @@ export interface OrchestratorEvents {
   /** The applied Reviewer terminal transition: `gate` (reviewed + ready) or
    *  `give-up` (ready-for-human). */
   reviewTransition(issue: number, transition: "gate" | "give-up"): void;
+  /** A Retry-budget attempt failed below the threshold (#98): `attempt` of
+   *  `limit` for `issue`+`phase` — no state changed, the item stays in its bucket. */
+  attemptFailed(issue: number, phase: string, attempt: number, limit: number): void;
+  /** The Retry budget for `issue`+`phase` was exhausted after `attempts` failed
+   *  attempts — the item was escalated to `ready-for-human` (#98). */
+  budgetExhausted(issue: number, phase: string, attempts: number): void;
 }
 
 /** Options for {@link createEvents}; every dependency is injectable for tests. */
@@ -638,5 +680,9 @@ export function createEvents(opts: CreateEventsOptions = {}): OrchestratorEvents
       emit({ type: "reviewer-outcome", issue, outcome, reason, ts: stamp() }),
     reviewTransition: (issue, transition) =>
       emit({ type: "review-transition", issue, transition, ts: stamp() }),
+    attemptFailed: (issue, phase, attempt, limit) =>
+      emit({ type: "attempt-failed", issue, phase, attempt, limit, ts: stamp() }),
+    budgetExhausted: (issue, phase, attempts) =>
+      emit({ type: "budget-exhausted", issue, phase, attempts, ts: stamp() }),
   };
 }

--- a/.sandcastle/events.test.mts
+++ b/.sandcastle/events.test.mts
@@ -179,6 +179,17 @@ describe("formatEventProse", () => {
     ).toBe("  → #7 escalated to ready-for-human (Reviewer gave up).");
   });
 
+  it("renders the Retry-budget attempt-failed and budget-exhausted lines (#98)", () => {
+    expect(
+      formatEventProse(
+        evt({ type: "attempt-failed", issue: 7, phase: "rev", attempt: 2, limit: 3 })
+      )
+    ).toBe("  ⚠ #7 rev attempt 2/3 failed — retrying.");
+    expect(
+      formatEventProse(evt({ type: "budget-exhausted", issue: 7, phase: "rev", attempts: 3 }))
+    ).toBe("  ⚠ #7 rev Retry budget exhausted after 3 attempts — escalated to ready-for-human.");
+  });
+
   it("renders nothing for a successful session-resolved (headless prose unchanged)", () => {
     expect(
       formatEventProse(
@@ -260,6 +271,8 @@ describe("formatEventProse", () => {
       { type: "landing-started", issue: 1, pr: 2, branch: "b" },
       { type: "landing-landed", issue: 1, pr: 2, branch: "b" },
       { type: "landing-failed", issue: 1, pr: 2, branch: "b", reason: "x" },
+      { type: "attempt-failed", issue: 1, phase: "impl", attempt: 1, limit: 3 },
+      { type: "budget-exhausted", issue: 1, phase: "impl", attempts: 3 },
     ];
     for (const s of samples) {
       expect(formatEventProse(evt(s))).toBeTypeOf("string");
@@ -284,6 +297,12 @@ describe("eventStream", () => {
     expect(eventStream(evt({ type: "planner-emitted", count: 1 }))).toBe("stdout");
     expect(eventStream(evt({ type: "planner-skipped" }))).toBe("stdout");
     expect(eventStream(evt({ type: "noop-escalated", issue: 1 }))).toBe("stdout");
+    expect(
+      eventStream(evt({ type: "attempt-failed", issue: 1, phase: "rev", attempt: 1, limit: 3 }))
+    ).toBe("stdout");
+    expect(
+      eventStream(evt({ type: "budget-exhausted", issue: 1, phase: "rev", attempts: 3 }))
+    ).toBe("stdout");
     expect(eventStream(evt({ type: "landing-started", issue: 1, pr: 2, branch: "b" }))).toBe(
       "stdout"
     );
@@ -483,6 +502,19 @@ describe("createEvents", () => {
     );
   });
 
+  it("emits the Retry-budget attempt-failed + budget-exhausted through the prose renderer", () => {
+    const out = vi.fn();
+    const err = vi.fn();
+    const events = createEvents({ format: "prose", out, err });
+    events.attemptFailed(7, "rev", 2, 3);
+    events.budgetExhausted(7, "rev", 3);
+    expect(out).toHaveBeenNthCalledWith(1, "  ⚠ #7 rev attempt 2/3 failed — retrying.");
+    expect(out).toHaveBeenNthCalledWith(
+      2,
+      "  ⚠ #7 rev Retry budget exhausted after 3 attempts — escalated to ready-for-human."
+    );
+  });
+
   it("emits the Landing lifecycle: started/landed to `out`, failed to `err`", () => {
     const out = vi.fn();
     const err = vi.fn();
@@ -607,6 +639,8 @@ describe("EVENT_TYPES / isKnownEventType", () => {
     "landing-started",
     "landing-landed",
     "landing-failed",
+    "attempt-failed",
+    "budget-exhausted",
   ];
 
   it("contains exactly every orchestrator event type, no more, no fewer", () => {
@@ -650,6 +684,12 @@ describe("eventSeverity", () => {
     ).toBe("warn");
     expect(
       eventSeverity(evt({ type: "reviewer-outcome", issue: 1, outcome: "none", reason: null }))
+    ).toBe("warn");
+    expect(
+      eventSeverity(evt({ type: "attempt-failed", issue: 1, phase: "rev", attempt: 2, limit: 3 }))
+    ).toBe("warn");
+    expect(
+      eventSeverity(evt({ type: "budget-exhausted", issue: 1, phase: "rev", attempts: 3 }))
     ).toBe("warn");
   });
 

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -5,13 +5,15 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 import {
   createInflight,
   createPool,
+  createRetryBudget,
+  escalateBudgetExhausted,
   filterReadyForAgent,
   filterReadyForMerge,
   filterReadyForReview,
   handleImplementerOutcome,
-  handleLandingFailure,
   handleReviewerOutcome,
   implementerSandboxSpec,
+  isBudgetExhausted,
   issueFromBranch,
   landingSandboxSpec,
   parseOutcome,
@@ -19,10 +21,12 @@ import {
   pickPrs,
   POLL_INTERVAL_MS,
   POOL_SIZE,
+  RETRY_BUDGET_N,
   resolvePlanEmit,
   shouldQueryBuckets,
   shouldRunPlanner,
   type BucketPr,
+  type BudgetTarget,
   type EmittedIssue,
   type ParsedOutcome,
   type PlanCache,
@@ -286,6 +290,45 @@ const inflight = createInflight();
 // Opus Planner call; `resolvePlanEmit` re-invokes the Planner only on a miss.
 let planCache: PlanCache = null;
 
+// The Retry budget (ADR-0011, #98): the in-memory failed-attempt counter keyed by
+// issue+phase, living beside the In-flight set and Plan cache (same non-durability
+// philosophy). A crashed Session, a Session with no parseable Outcome, or a failed
+// Landing is one failed attempt; a successful Session clears the counter. On the
+// N=3rd attempt for an issue+phase, `recordFailedAttempt` escalates to
+// ready-for-human and clears the counter (a re-labeling human gets a fresh budget).
+const budget = createRetryBudget();
+
+/**
+ * Record one failed attempt against the Retry budget for `issue`+`phase` and act
+ * on it (ADR-0011, #98). Below the threshold: no GitHub state changes — the item
+ * stays in its Dispatch bucket for re-dispatch — and an `attempt-failed` event
+ * makes the struggling item visible. On the N=3rd attempt: clear the counter
+ * (BEFORE escalating, so a human re-labeling the item starts fresh) and escalate
+ * to `ready-for-human` via the shape-aware {@link escalateBudgetExhausted}
+ * (issue-shaped for implement, PR-shaped for review/land), then emit
+ * `budget-exhausted`. A gh failure during escalation is tolerated — it must not
+ * crash the orchestrator loop; the next tick re-dispatches and re-attempts.
+ */
+async function recordFailedAttempt(
+  target: BudgetTarget,
+  phase: string,
+  issue: number,
+  detail?: string
+): Promise<void> {
+  const attempts = budget.fail(issue, phase);
+  if (isBudgetExhausted(attempts)) {
+    budget.clear(issue, phase);
+    try {
+      await escalateBudgetExhausted(target, phase, attempts, ghRunner, detail);
+    } catch (escErr) {
+      events.ghError(["budget-escalate", phase, String(issue)], errorMessage(escErr));
+    }
+    events.budgetExhausted(issue, phase, attempts);
+  } else {
+    events.attemptFailed(issue, phase, attempts, RETRY_BUDGET_N);
+  }
+}
+
 /**
  * Dispatch one Implementer for an issue into the shared Pool. Occupies a slot
  * (acquire), marks the issue in-flight, opens a fresh sandbox, runs the
@@ -347,6 +390,9 @@ async function dispatchImplementer(issue: {
       status: "ok",
       commits: result.commits.length,
     });
+    // A successful Session (the run resolved, crash-free) clears the impl Retry
+    // budget for this issue (ADR-0011): a later transient failure starts fresh.
+    budget.clear(issue.number, "impl");
 
     // No-op terminal handling (ADR-0006): zero commits → no draft PR → strip
     // ready-for-agent, add ready-for-human, comment, so it is not re-dispatched.
@@ -363,6 +409,16 @@ async function dispatchImplementer(issue: {
       commits: 0,
       error: errorMessage(err),
     });
+    // A CRASHED Implementer is a failed attempt against the Retry budget (ADR-0011,
+    // #98) — not escalated on its own (a crash may be transient, ADR-0006), but
+    // bounded so a deterministically-crashing issue no longer re-dispatches forever.
+    // Issue-shaped: on exhaustion, strip ready-for-agent + add ready-for-human.
+    await recordFailedAttempt(
+      { kind: "issue", issue: issue.number },
+      "impl",
+      issue.number,
+      errorMessage(err)
+    );
   } finally {
     implLC.done();
     inflight.delete(issue.number);
@@ -443,7 +499,7 @@ async function dispatchReviewer(pr: {
     // ADR-0011: the agent judged; the orchestrator mutates. Parse the reported
     // Outcome and perform the terminal transition ourselves. A missing/garbled
     // Outcome (parseOutcome → null) triggers NO GitHub mutation — the review is
-    // left for re-dispatch (a Retry-budget attempt in a follow-up issue).
+    // left for re-dispatch and spends a Retry-budget attempt (the else branch, #98).
     const outcome = parseOutcome(result.stdout);
     events.reviewerOutcome(
       pr.issue,
@@ -451,8 +507,22 @@ async function dispatchReviewer(pr: {
       outcome?.kind === "give-up" ? outcome.reason : null
     );
     if (outcome) {
+      // A parsed Outcome (pass or give-up) is a successful Session — clear the rev
+      // Retry budget for this issue before performing the terminal transition.
+      budget.clear(pr.issue, "rev");
       const transition = await handleReviewerOutcome(outcome, pr, ghRunner);
       events.reviewTransition(pr.issue, transition);
+    } else {
+      // No parseable Outcome (agent rambled / forgot the tag / hit max iterations):
+      // a failed attempt against the Retry budget (ADR-0011, #98). No GitHub state
+      // changes below the threshold — the draft PR stays in the ready-for-review
+      // bucket for re-dispatch. PR-shaped, gated:false (the PR is a plain draft).
+      await recordFailedAttempt(
+        { kind: "pr", prNumber: pr.prNumber, gated: false },
+        "rev",
+        pr.issue,
+        "the Session produced no parseable Outcome"
+      );
     }
   } catch (err) {
     events.sessionResolved({
@@ -463,6 +533,14 @@ async function dispatchReviewer(pr: {
       commits: 0,
       error: errorMessage(err),
     });
+    // A CRASHED Reviewer is a failed attempt against the Retry budget (#98). Same
+    // PR-shaped, gated:false escalation on exhaustion as the no-Outcome case.
+    await recordFailedAttempt(
+      { kind: "pr", prNumber: pr.prNumber, gated: false },
+      "rev",
+      pr.issue,
+      errorMessage(err)
+    );
   } finally {
     lc.done();
     inflight.delete(pr.issue);
@@ -485,13 +563,15 @@ async function dispatchReviewer(pr: {
  * entry under the issue's runId.
  *
  * On failure — conflict, red suite, or the merge command failing — the ready +
- * `reviewed` PR is escalated to `ready-for-human` via {@link handleLandingFailure}
- * (the crash-safe PR-shaped transition runner: terminal label first, then strip
- * `reviewed`/ready, then comment the failure output). A follow-up replaces this
- * escalation with the Conflict resolver dispatch, and the Retry budget makes
- * failed Landings spend attempts (ADR-0012). Whatever happens, the finally
- * disposes the sandbox, removes the issue from the In-flight set, and frees the
- * Pool slot. The runId is issue-derived, shared with impl/rev.
+ * `reviewed` PR spends one Retry-budget attempt via {@link recordFailedAttempt}
+ * (ADR-0011, #98): below the threshold NO GitHub state changes and the PR stays in
+ * the ready-for-merge bucket for a re-land next tick; on the N=3rd attempt the
+ * PR-shaped gated escalation strips the `reviewed` gate + reverts to draft and
+ * hands the PR to a human (crash-safe: terminal label first). A follow-up replaces
+ * the re-land with a Conflict resolver dispatch on the first failure (ADR-0012).
+ * Whatever happens, the finally disposes the sandbox, removes the issue from the
+ * In-flight set, and frees the Pool slot. The runId is issue-derived, shared with
+ * impl/rev.
  */
 async function dispatchLanding(pr: {
   prNumber: number;
@@ -544,6 +624,8 @@ async function dispatchLanding(pr: {
       })
     );
     events.landingLanded(pr.prNumber, pr.issue, pr.branch);
+    // A successful Landing clears the land Retry budget for this issue (ADR-0011).
+    budget.clear(pr.issue, "land");
   } catch (err) {
     const failure = errorMessage(err);
     // Record the failed Landing as an agent-free Manifest entry (no Transcript).
@@ -559,14 +641,18 @@ async function dispatchLanding(pr: {
         endedAt: new Date(),
       })
     );
-    // Escalate the ready + reviewed PR to a human (crash-safe transition runner).
-    // Best-effort: a gh failure here must not crash the orchestrator loop.
-    try {
-      await handleLandingFailure({ prNumber: pr.prNumber }, failure, ghRunner);
-    } catch (escErr) {
-      events.ghError(["landing-escalate", String(pr.prNumber)], errorMessage(escErr));
-    }
     events.landingFailed(pr.prNumber, pr.issue, pr.branch, failure);
+    // A failed Landing — textual conflict or red suite — is a failed attempt against
+    // the Retry budget (ADR-0011/0012, #98), NOT an immediate escalation: below the
+    // threshold no GitHub state changes and the ready + `reviewed` PR stays in the
+    // ready-for-merge bucket for a re-land next tick. On exhaustion, escalate the
+    // PR-shaped gated target (strip the `reviewed` gate + revert to draft) to a human.
+    await recordFailedAttempt(
+      { kind: "pr", prNumber: pr.prNumber, gated: true },
+      "land",
+      pr.issue,
+      failure
+    );
   } finally {
     lc.done();
     inflight.delete(pr.issue);


### PR DESCRIPTION
Closes #98. Final slice of ADR-0011: the **Retry budget** that bounds the previously-unbounded "a deterministically-failing item re-dispatches (and burns a sandbox) every eligible Poll tick forever" hole.

## What changed

**Pure budget module** (`dispatch.mts`)
- `createRetryBudget()` — in-memory counter keyed by `issue+phase`, beside the In-flight set and Plan cache (same non-durability philosophy, ADR-0006/0010). `fail`/`clear`/`count`.
- `RETRY_BUDGET_N = 3` + `isBudgetExhausted(count)` — one attempt plus two retries.
- `budgetExhaustedComment(phase, attempts, detail?)` — cites the attempt count (+ last-failure detail).
- `escalateBudgetExhausted(target, phase, attempts, gh, detail?)` — shape-aware and crash-safe (terminal label first): `{kind:"issue"}` for implement, `{kind:"pr", gated}` for review (`gated:false`, draft untouched) / land (`gated:true`, strips the `reviewed` gate + reverts to draft).
- Removes the superseded `handleLandingFailure` / `landingFailureComment` (ADR-0012's interim straight-to-human escalation), now replaced by the budget-gated path.

**Wiring** (`main.mts`)
- A `budget` instance + a `recordFailedAttempt` helper: below the threshold it emits `attempt-failed` and changes **no GitHub state** (the item stays in its Dispatch bucket); on the N=3rd it clears the counter (so a re-labeling human gets a fresh budget), escalates via `escalateBudgetExhausted`, and emits `budget-exhausted`.
- **Implementer**: crash → `impl` attempt; success clears.
- **Reviewer**: crash **and** no-parseable-Outcome → `rev` attempt; a parsed Outcome clears.
- **Landing**: failure → `land` attempt — replaces the old immediate escalation, so a failed Landing re-lands below threshold and only escalates on the 3rd.

**Live feed** (`events.mts`) — `attempt-failed` (n of N) and `budget-exhausted` across all renderers (prose, Cockpit log, NDJSON) + severity + the decode allow-list.

## Acceptance criteria
- [x] Pure budget module unit-tested: increment, threshold, clear-on-success, clear-on-escalate
- [x] Crashed + no-Outcome Sessions count as failed attempts (Implementer, Reviewer); a failed Landing counts for the merge phase
- [x] The 3rd failed attempt escalates to `ready-for-human` with a comment citing the count, then clears the counter
- [x] Escalation works for both shapes: issue (implement) and PR (review/land)
- [x] Below the threshold, a failed attempt changes no GitHub state and the item stays in its bucket
- [x] `attempt-failed` and `budget-exhausted` appear in the Live feed (both renderers)
- [x] `pnpm typecheck` and `pnpm test` green (517 passed)

## Note on the Conflict-resolver (`resolve`) phase
The Conflict resolver isn't dispatched anywhere yet (a future ADR-0012 slice — no `dispatchResolver`, no resolve prompt). The budget and escalation are fully phase-agnostic, so `resolve` is covered at the pure-module level (explicit test) and will work when that dispatch lands. No fabricated wire point was added for code that doesn't exist yet.

Built test-first (TDD), one RED→GREEN slice at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)