### PR TITLE
#101 Conflict resolver: agent role for failed Landings, with re-review before landing (ADR-0012)

### DIFF
--- a/.sandcastle/dispatch.mts
+++ b/.sandcastle/dispatch.mts
@@ -630,6 +630,35 @@ export async function handleReviewerOutcome(
   return "give-up";
 }
 
+// ---- Conflict resolver PASS re-queue (ADR-0012, #101) ---------------------
+
+/**
+ * Re-queue a resolved PR for review (CONTEXT.md: Conflict resolver; ADR-0012).
+ * When a Conflict resolver reports `pass` — it merged `origin/main` into the PR
+ * branch, got the suite green, and pushed — the orchestrator strips the
+ * `reviewed` gate and reverts the PR draft → so it re-enters the ready-for-review
+ * bucket and is **re-reviewed before it can land again**. This is a **re-queue,
+ * not an escalation**: no terminal `ready-for-human` label is added, so the
+ * crash-safe terminal-label-first ordering does NOT apply here. The strip order
+ * mirrors the gated budget escalation ({@link escalateBudgetExhausted}): remove
+ * `reviewed`, then `pr ready --undo`.
+ *
+ * A resolver give-up or missing Outcome is NOT handled here — it spends a
+ * merge-phase Retry-budget attempt (the shared `land` counter) in the
+ * orchestrator, escalating to `ready-for-human` only on exhaustion.
+ *
+ * Pure logic over an injectable {@link GhRunner}, so the transition is
+ * unit-testable in isolation.
+ */
+export async function requeueResolvedPr(
+  pr: { readonly prNumber: number },
+  gh: GhRunner
+): Promise<void> {
+  const n = String(pr.prNumber);
+  await gh.run(["pr", "edit", n, "--remove-label", "reviewed"]);
+  await gh.run(["pr", "ready", n, "--undo"]);
+}
+
 // ---- Retry-budget escalation (ADR-0011, #98) ------------------------------
 
 /**

--- a/.sandcastle/dispatch.test.mts
+++ b/.sandcastle/dispatch.test.mts
@@ -25,6 +25,7 @@ import {
   pickImplementers,
   pickPrs,
   planCacheKey,
+  requeueResolvedPr,
   resolvePlanEmit,
   reviewerGiveUpComment,
   shouldQueryBuckets,
@@ -587,6 +588,33 @@ describe("reviewerGiveUpComment", () => {
     const body = reviewerGiveUpComment("missing dependency");
     expect(body).toContain("missing dependency");
     expect(body).toMatch(/out of all Dispatch buckets; a human owns it/i);
+  });
+});
+
+// ---- #101 — Conflict resolver PASS re-queue transition (ADR-0012) ----------
+//
+// A resolver PASS is NOT a landing and NOT an escalation: the resolved branch
+// must be re-reviewed before it can land again (ADR-0012). `requeueResolvedPr`
+// strips the `reviewed` gate and reverts the PR to draft so it re-enters the
+// ready-for-review bucket. The terminal-label-first ordering rule does not apply
+// here (no terminal label is added) — this is a re-queue, not a give-up. A
+// resolver give-up / missing Outcome is NOT handled here; it spends a merge-phase
+// Retry-budget attempt in the orchestrator (the shared `land` counter).
+describe("requeueResolvedPr", () => {
+  it("strips the reviewed gate and reverts the PR to draft (re-queue for review)", async () => {
+    const gh = mockGh();
+    await requeueResolvedPr({ prNumber: 7 }, gh);
+    const calls = gh.calls.map((c) => c.join(" "));
+    expect(calls.some((s) => /pr edit 7 --remove-label reviewed/.test(s))).toBe(true);
+    expect(calls.some((s) => /pr ready 7 --undo/.test(s))).toBe(true);
+  });
+
+  it("is a re-queue, not an escalation: never touches ready-for-human and never re-adds reviewed", async () => {
+    const gh = mockGh();
+    await requeueResolvedPr({ prNumber: 7 }, gh);
+    const calls = gh.calls.map((c) => c.join(" "));
+    expect(calls.some((s) => /ready-for-human/.test(s))).toBe(false);
+    expect(calls.some((s) => /--add-label reviewed/.test(s))).toBe(false);
   });
 });
 

--- a/.sandcastle/events.mts
+++ b/.sandcastle/events.mts
@@ -38,7 +38,7 @@ export type EventFormat = "prose" | "ndjson";
  *  every renderer speaks (see {@link ROLE_LABELS}). The merge phase is NOT here:
  *  the Landing is agent-free (ADR-0012) and flows through its own `landing-*`
  *  events, not the Session-shaped `dispatch` / `session-resolved` ones. */
-export type OrchestratorRole = "implementer" | "reviewer";
+export type OrchestratorRole = "implementer" | "reviewer" | "resolver";
 
 /** Shared fields carried by every event. The NDJSON renderer keeps `ts`. */
 interface BaseEvent {
@@ -162,6 +162,25 @@ interface ReviewTransitionEvent extends BaseEvent {
   readonly transition: "gate" | "give-up";
 }
 
+/** The orchestrator parsed a Conflict-resolver Session's Outcome (ADR-0012):
+ *  `pass` (branch resolved + pushed), `give-up` (with its one-line `reason`), or
+ *  `none` when the Session produced no parseable Outcome tag. give-up / none each
+ *  spend a merge-phase Retry-budget attempt (the shared `land` counter). */
+interface ResolverOutcomeEvent extends BaseEvent {
+  readonly type: "resolver-outcome";
+  readonly issue: number;
+  readonly outcome: "pass" | "give-up" | "none";
+  readonly reason: string | null;
+}
+
+/** The orchestrator applied a resolver PASS re-queue (ADR-0012): it stripped the
+ *  `reviewed` gate and reverted the PR to draft, so the resolved branch re-enters
+ *  the ready-for-review bucket. A re-queue, NOT an escalation. */
+interface ResolverRequeuedEvent extends BaseEvent {
+  readonly type: "resolver-requeued";
+  readonly issue: number;
+}
+
 /** A Landing (the agent-free merge phase, ADR-0012) began: it took a Pool slot
  *  and started its sandbox lifecycle for a ready + `reviewed` PR. Not a Session
  *  (`dispatch`) — a Landing runs no agent. */
@@ -182,8 +201,9 @@ interface LandingLandedEvent extends BaseEvent {
 }
 
 /** A Landing failed — a textual `git merge` conflict or a red suite after a clean
- *  merge — so the PR was escalated to `ready-for-human` (ADR-0012, this slice).
- *  `reason` is the one-line failure summary. */
+ *  merge — so the orchestrator spends a merge-phase attempt and dispatches the
+ *  Conflict resolver (or escalates to `ready-for-human` on budget exhaustion)
+ *  (ADR-0012). `reason` is the one-line failure summary. */
 interface LandingFailedEvent extends BaseEvent {
   readonly type: "landing-failed";
   readonly issue: number;
@@ -234,6 +254,8 @@ export type OrchestratorEvent =
   | SessionResolvedEvent
   | ReviewerOutcomeEvent
   | ReviewTransitionEvent
+  | ResolverOutcomeEvent
+  | ResolverRequeuedEvent
   | LandingStartedEvent
   | LandingLandedEvent
   | LandingFailedEvent
@@ -293,6 +315,13 @@ export function formatEventProse(event: OrchestratorEvent): string | null {
       return event.transition === "gate"
         ? `  → review gate opened for #${event.issue} (reviewed + ready).`
         : `  → #${event.issue} escalated to ready-for-human (Reviewer gave up).`;
+    case "resolver-outcome":
+      if (event.outcome === "pass") return `  ✓ Conflict resolver #${event.issue} reported pass.`;
+      if (event.outcome === "give-up")
+        return `  ⚠ Conflict resolver #${event.issue} gave up: ${event.reason}`;
+      return `  ⚠ Conflict resolver #${event.issue} reported no parseable Outcome — no state change.`;
+    case "resolver-requeued":
+      return `  → #${event.issue} resolved — reverted to draft for re-review (reviewed stripped).`;
     case "landing-started":
       return `  → landing PR #${event.pr} (issue #${event.issue}) → ${event.branch}`;
     case "landing-landed":
@@ -315,6 +344,7 @@ export function formatEventProse(event: OrchestratorEvent): string | null {
 const ROLE_LABELS: Record<OrchestratorRole, { readonly word: string; readonly abbr: string }> = {
   implementer: { word: "Implementer", abbr: "impl" },
   reviewer: { word: "Reviewer", abbr: "rev" },
+  resolver: { word: "Conflict resolver", abbr: "res" },
 };
 
 /** The capitalized role word for a dispatch line (`Implementer`/`Reviewer`). */
@@ -412,6 +442,13 @@ export function formatEventLog(event: OrchestratorEvent): string {
       return event.transition === "gate"
         ? `→ #${event.issue} gate opened · reviewed + ready`
         : `→ #${event.issue} escalated to ready-for-human`;
+    case "resolver-outcome":
+      if (event.outcome === "give-up")
+        return `⚠ res #${event.issue} outcome · give-up · ${event.reason}`;
+      if (event.outcome === "none") return `⚠ res #${event.issue} outcome · none`;
+      return `✓ res #${event.issue} outcome · pass`;
+    case "resolver-requeued":
+      return `→ #${event.issue} re-queued for review · draft + reviewed stripped`;
     case "landing-started":
       return `▶ landing PR #${event.pr} (#${event.issue})`;
     case "landing-landed":
@@ -456,6 +493,7 @@ export function eventSeverity(event: OrchestratorEvent): EventSeverity {
     case "budget-exhausted":
       return "warn";
     case "reviewer-outcome":
+    case "resolver-outcome":
       // A give-up or no-parseable-Outcome is a soft escalation (warn); a pass is
       // routine progress (normal).
       return event.outcome === "pass" ? "normal" : "warn";
@@ -467,6 +505,7 @@ export function eventSeverity(event: OrchestratorEvent): EventSeverity {
     case "plan-reused":
     case "planner-skipped":
     case "review-transition":
+    case "resolver-requeued":
     case "landing-started":
     case "landing-landed":
       return "normal";
@@ -500,6 +539,8 @@ const EVENT_TYPE_TAGS: Record<OrchestratorEvent["type"], true> = {
   "session-resolved": true,
   "reviewer-outcome": true,
   "review-transition": true,
+  "resolver-outcome": true,
+  "resolver-requeued": true,
   "landing-started": true,
   "landing-landed": true,
   "landing-failed": true,
@@ -559,11 +600,15 @@ export interface OrchestratorEvents {
   dispatchImplementer(issue: number, title: string, branch: string): void;
   /** Dispatching a Reviewer for `pr` (issue `issue`, branch `branch`). */
   dispatchReviewer(pr: number, issue: number, branch: string): void;
+  /** Dispatching a Conflict resolver for `pr` (issue `issue`, branch `branch`)
+   *  after a failed Landing (ADR-0012). */
+  dispatchResolver(pr: number, issue: number, branch: string): void;
   /** A Landing began for `pr` (issue `issue`, branch `branch`) — took a Pool slot. */
   landingStarted(pr: number, issue: number, branch: string): void;
   /** A Landing succeeded: the PR merged clean + green (`gh pr merge` ran). */
   landingLanded(pr: number, issue: number, branch: string): void;
-  /** A Landing failed (conflict / red suite), escalated to `ready-for-human`. */
+  /** A Landing failed (conflict / red suite) — spends a merge-phase attempt and
+   *  dispatches the Conflict resolver (or escalates on budget exhaustion). */
   landingFailed(pr: number, issue: number, branch: string, reason: string): void;
   /** The Planner emitted `count` unblocked issues. */
   plannerEmitted(count: number): void;
@@ -597,6 +642,12 @@ export interface OrchestratorEvents {
   /** The applied Reviewer terminal transition: `gate` (reviewed + ready) or
    *  `give-up` (ready-for-human). */
   reviewTransition(issue: number, transition: "gate" | "give-up"): void;
+  /** The Conflict resolver's parsed Outcome (ADR-0012): `pass` / `give-up` (with
+   *  `reason`) / `none` when no parseable Outcome tag was produced. */
+  resolverOutcome(issue: number, outcome: "pass" | "give-up" | "none", reason: string | null): void;
+  /** The applied resolver PASS re-queue: `reviewed` stripped + PR reverted to
+   *  draft so it re-enters the ready-for-review bucket (ADR-0012). */
+  resolverRequeued(issue: number): void;
   /** A Retry-budget attempt failed below the threshold (#98): `attempt` of
    *  `limit` for `issue`+`phase` — no state changed, the item stays in its bucket. */
   attemptFailed(issue: number, phase: string, attempt: number, limit: number): void;
@@ -651,6 +702,8 @@ export function createEvents(opts: CreateEventsOptions = {}): OrchestratorEvents
       emit({ type: "dispatch", role: "implementer", issue, branch, pr: null, title, ts: stamp() }),
     dispatchReviewer: (pr, issue, branch) =>
       emit({ type: "dispatch", role: "reviewer", issue, branch, pr, title: null, ts: stamp() }),
+    dispatchResolver: (pr, issue, branch) =>
+      emit({ type: "dispatch", role: "resolver", issue, branch, pr, title: null, ts: stamp() }),
     landingStarted: (pr, issue, branch) =>
       emit({ type: "landing-started", pr, issue, branch, ts: stamp() }),
     landingLanded: (pr, issue, branch) =>
@@ -680,6 +733,9 @@ export function createEvents(opts: CreateEventsOptions = {}): OrchestratorEvents
       emit({ type: "reviewer-outcome", issue, outcome, reason, ts: stamp() }),
     reviewTransition: (issue, transition) =>
       emit({ type: "review-transition", issue, transition, ts: stamp() }),
+    resolverOutcome: (issue, outcome, reason) =>
+      emit({ type: "resolver-outcome", issue, outcome, reason, ts: stamp() }),
+    resolverRequeued: (issue) => emit({ type: "resolver-requeued", issue, ts: stamp() }),
     attemptFailed: (issue, phase, attempt, limit) =>
       emit({ type: "attempt-failed", issue, phase, attempt, limit, ts: stamp() }),
     budgetExhausted: (issue, phase, attempts) =>

--- a/.sandcastle/events.test.mts
+++ b/.sandcastle/events.test.mts
@@ -179,6 +179,26 @@ describe("formatEventProse", () => {
     ).toBe("  → #7 escalated to ready-for-human (Reviewer gave up).");
   });
 
+  it("renders the parsed Conflict-resolver Outcome (pass / give-up / none) (#101)", () => {
+    expect(
+      formatEventProse(evt({ type: "resolver-outcome", issue: 7, outcome: "pass", reason: null }))
+    ).toBe("  ✓ Conflict resolver #7 reported pass.");
+    expect(
+      formatEventProse(
+        evt({ type: "resolver-outcome", issue: 7, outcome: "give-up", reason: "still red" })
+      )
+    ).toBe("  ⚠ Conflict resolver #7 gave up: still red");
+    expect(
+      formatEventProse(evt({ type: "resolver-outcome", issue: 7, outcome: "none", reason: null }))
+    ).toBe("  ⚠ Conflict resolver #7 reported no parseable Outcome — no state change.");
+  });
+
+  it("renders the resolver PASS re-queue transition (#101)", () => {
+    expect(formatEventProse(evt({ type: "resolver-requeued", issue: 7 }))).toBe(
+      "  → #7 resolved — reverted to draft for re-review (reviewed stripped)."
+    );
+  });
+
   it("renders the Retry-budget attempt-failed and budget-exhausted lines (#98)", () => {
     expect(
       formatEventProse(
@@ -636,6 +656,8 @@ describe("EVENT_TYPES / isKnownEventType", () => {
     "session-resolved",
     "reviewer-outcome",
     "review-transition",
+    "resolver-outcome",
+    "resolver-requeued",
     "landing-started",
     "landing-landed",
     "landing-failed",

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -21,6 +21,7 @@ import {
   pickPrs,
   POLL_INTERVAL_MS,
   POOL_SIZE,
+  requeueResolvedPr,
   RETRY_BUDGET_N,
   resolvePlanEmit,
   shouldQueryBuckets,
@@ -54,6 +55,10 @@ const MODELS = {
   PLANNING: "claude-opus-4-8",
   IMPLEMENTATION: "litellm/glm-5.1",
   REVIEW: "claude-opus-4-8",
+  // The Conflict resolver integrates a reviewed branch with origin/main — a
+  // careful, high-stakes merge (ADR-0012), so it runs on the same Opus model as
+  // review rather than the cheaper implementation model.
+  RESOLUTION: "claude-opus-4-8",
 };
 
 // Sandbox factory — use this everywhere instead of calling docker() directly.
@@ -279,7 +284,10 @@ const events = createEvents();
 // orchestrator acts on — the review gate + give-up transitions are performed here
 // in code (ADR-0011, #96). The merge phase is the deterministic, agent-free
 // Landing: the orchestrator merges + validates in a sandbox and runs
-// `gh pr merge` itself, escalating a failed Landing to ready-for-human (ADR-0012).
+// `gh pr merge` itself; a failed Landing spends a merge-phase attempt and
+// dispatches the Conflict resolver, which merges origin/main into the branch,
+// fixes it green, and routes it back through review — escalating to
+// ready-for-human only on Retry-budget exhaustion (ADR-0012, #101).
 const pool = createPool(POOL_SIZE);
 const inflight = createInflight();
 
@@ -308,13 +316,18 @@ const budget = createRetryBudget();
  * (issue-shaped for implement, PR-shaped for review/land), then emit
  * `budget-exhausted`. A gh failure during escalation is tolerated — it must not
  * crash the orchestrator loop; the next tick re-dispatches and re-attempts.
+ *
+ * Returns whether it **escalated** (the threshold was hit) so a caller can branch
+ * on it — the failed Landing hands off to the Conflict resolver only when it did
+ * NOT escalate (below the threshold); on exhaustion the item is already handed to
+ * a human (ADR-0012).
  */
 async function recordFailedAttempt(
   target: BudgetTarget,
   phase: string,
   issue: number,
   detail?: string
-): Promise<void> {
+): Promise<boolean> {
   const attempts = budget.fail(issue, phase);
   if (isBudgetExhausted(attempts)) {
     budget.clear(issue, phase);
@@ -324,9 +337,10 @@ async function recordFailedAttempt(
       events.ghError(["budget-escalate", phase, String(issue)], errorMessage(escErr));
     }
     events.budgetExhausted(issue, phase, attempts);
-  } else {
-    events.attemptFailed(issue, phase, attempts, RETRY_BUDGET_N);
+    return true;
   }
+  events.attemptFailed(issue, phase, attempts, RETRY_BUDGET_N);
+  return false;
 }
 
 /**
@@ -563,15 +577,18 @@ async function dispatchReviewer(pr: {
  * entry under the issue's runId.
  *
  * On failure — conflict, red suite, or the merge command failing — the ready +
- * `reviewed` PR spends one Retry-budget attempt via {@link recordFailedAttempt}
- * (ADR-0011, #98): below the threshold NO GitHub state changes and the PR stays in
- * the ready-for-merge bucket for a re-land next tick; on the N=3rd attempt the
+ * `reviewed` PR spends one merge-phase ("land") Retry-budget attempt via
+ * {@link recordFailedAttempt} (ADR-0011/0012, #98): on the N=3rd attempt the
  * PR-shaped gated escalation strips the `reviewed` gate + reverts to draft and
- * hands the PR to a human (crash-safe: terminal label first). A follow-up replaces
- * the re-land with a Conflict resolver dispatch on the first failure (ADR-0012).
- * Whatever happens, the finally disposes the sandbox, removes the issue from the
- * In-flight set, and frees the Pool slot. The runId is issue-derived, shared with
- * impl/rev.
+ * hands the PR to a human (crash-safe: terminal label first). **Below the
+ * threshold, the orchestrator dispatches the Conflict resolver** ({@link
+ * dispatchResolver}) instead of escalating — it merges `origin/main` into the
+ * branch, fixes it green, and routes it back through review (ADR-0012). The issue
+ * is kept in-flight across the handoff (`handoff` short-circuits the finally's
+ * `inflight.delete`) so no re-Landing races in before the resolver runs; the
+ * resolver takes ownership of clearing it. Whatever happens, the finally disposes
+ * the sandbox and frees the Pool slot. The runId is issue-derived, shared with
+ * impl/rev/resolve.
  */
 async function dispatchLanding(pr: {
   prNumber: number;
@@ -584,6 +601,9 @@ async function dispatchLanding(pr: {
   const lc = lifecycle(label);
   lc.start();
   const startedAt = new Date();
+  // Did a failed Landing hand off to the Conflict resolver? Then keep the issue
+  // in-flight (the resolver owns removing it) so no re-Landing races in.
+  let handoff = false;
   events.landingStarted(pr.prNumber, pr.issue, pr.branch);
   try {
     // Validate in an ISOLATED worktree forked from `origin/main`, NOT head mode. A
@@ -642,16 +662,146 @@ async function dispatchLanding(pr: {
       })
     );
     events.landingFailed(pr.prNumber, pr.issue, pr.branch, failure);
-    // A failed Landing — textual conflict or red suite — is a failed attempt against
-    // the Retry budget (ADR-0011/0012, #98), NOT an immediate escalation: below the
-    // threshold no GitHub state changes and the ready + `reviewed` PR stays in the
-    // ready-for-merge bucket for a re-land next tick. On exhaustion, escalate the
-    // PR-shaped gated target (strip the `reviewed` gate + revert to draft) to a human.
-    await recordFailedAttempt(
+    // A failed Landing — textual conflict or red suite — spends one merge-phase
+    // ("land") Retry-budget attempt (ADR-0011/0012, #98). On exhaustion the
+    // PR-shaped gated escalation (strip the `reviewed` gate + revert to draft)
+    // hands the PR to a human. Below the threshold, dispatch the Conflict resolver
+    // instead of escalating — keep the issue in-flight across the handoff.
+    const escalated = await recordFailedAttempt(
       { kind: "pr", prNumber: pr.prNumber, gated: true },
       "land",
       pr.issue,
       failure
+    );
+    handoff = !escalated;
+  } finally {
+    lc.done();
+    // On a resolver handoff the issue stays in-flight — dispatchResolver clears it
+    // when it resolves. Otherwise (landed, or escalated) remove it here.
+    if (!handoff) inflight.delete(pr.issue);
+    pool.release();
+  }
+  if (handoff) {
+    events.dispatchResolver(pr.prNumber, pr.issue, pr.branch);
+    void dispatchResolver(pr); // fire-and-forget; acquires its own Pool slot.
+  }
+}
+
+/**
+ * Dispatch one Conflict resolver for a PR whose Landing failed (CONTEXT.md:
+ * Conflict resolver; ADR-0012). Occupies its own Pool slot (acquire) — the issue
+ * is already in-flight from the failed Landing that handed off to it, kept so no
+ * re-Landing races in. In a **fresh sandbox checked out on the PR branch** (like
+ * the Reviewer, decoupled from the Landing's disposed sandbox) it runs
+ * resolve-prompt.md: the agent merges `origin/main` INTO the branch, fixes the
+ * conflicts / integration breakage until `pnpm typecheck && pnpm test` are green,
+ * pushes, and ends its Session with a structured **Outcome** (ADR-0011). The
+ * orchestrator parses it and mutates GitHub state itself:
+ *
+ * - **pass** → {@link requeueResolvedPr}: strip the `reviewed` gate + revert the
+ *   PR to draft so it re-enters the ready-for-review bucket and is re-reviewed
+ *   before it can land again. The `land` Retry budget is deliberately NOT cleared
+ *   — it is the shared merge-phase counter that bounds the
+ *   Landing → resolve → review → Landing loop (a successful *Landing* clears it).
+ * - **give-up / no parseable Outcome / crash** → spends another merge-phase
+ *   (`land`) Retry-budget attempt via {@link recordFailedAttempt}; on exhaustion
+ *   the gated escalation hands the PR to a human. Below the threshold the PR stays
+ *   ready + `reviewed`, so the next tick re-Lands it (which re-enters this path).
+ *
+ * Whatever happens, the finally disposes the sandbox, removes the issue from the
+ * In-flight set (ownership handed over by the Landing), and frees the Pool slot.
+ * The Manifest/Live-feed phase is `resolve`; the runId is issue-derived, shared
+ * with impl/rev/land.
+ */
+async function dispatchResolver(pr: {
+  prNumber: number;
+  issue: number;
+  branch: string;
+}): Promise<void> {
+  await pool.acquire();
+  const issueRunId = generateRunId(pr.issue);
+  const label = "resolve #" + pr.issue;
+  const lc = lifecycle(label);
+  lc.start();
+  try {
+    await using sandbox = await sandcastle.createSandbox({
+      sandbox: dockerSandbox(),
+      branch: pr.branch,
+      copyToWorktree: ["node_modules"],
+      hooks: {
+        sandbox: {
+          onSandboxReady: [{ command: "pnpm install --frozen-lockfile && pnpm build" }],
+        },
+      },
+    });
+    lc.sandbox();
+
+    const result = await recordedRun({
+      runId: issueRunId,
+      phase: "resolve",
+      issue: pr.issue,
+      branch: pr.branch,
+      // ADR-0011: record the resolver's parsed Outcome in the Manifest entry.
+      outcome: (r) => parseOutcome(r.stdout),
+      run: () =>
+        sandbox.run({
+          name: "Conflict resolver #" + pr.issue,
+          agent: sandcastle.pi(MODELS.RESOLUTION, piSessions),
+          promptFile: "./.sandcastle/resolve-prompt.md",
+          promptArgs: {
+            ISSUE_NUMBER: String(pr.issue),
+            ISSUE_TITLE: "Issue #" + pr.issue,
+            BRANCH: pr.branch,
+          },
+          logging: observe(label),
+        }),
+    });
+    events.sessionResolved({
+      role: "resolver",
+      issue: pr.issue,
+      branch: pr.branch,
+      status: "ok",
+      commits: result.commits.length,
+    });
+
+    // ADR-0012: the agent judged; the orchestrator mutates. On pass, re-queue the
+    // resolved branch for review; on give-up / no parseable Outcome, spend a
+    // merge-phase (`land`) attempt (the shared counter that bounds the loop).
+    const outcome = parseOutcome(result.stdout);
+    events.resolverOutcome(
+      pr.issue,
+      outcome?.kind ?? "none",
+      outcome?.kind === "give-up" ? outcome.reason : null
+    );
+    if (outcome?.kind === "pass") {
+      await requeueResolvedPr(pr, ghRunner);
+      events.resolverRequeued(pr.issue);
+    } else {
+      const reason =
+        outcome?.kind === "give-up" ? outcome.reason : "the resolver produced no parseable Outcome";
+      await recordFailedAttempt(
+        { kind: "pr", prNumber: pr.prNumber, gated: true },
+        "land",
+        pr.issue,
+        reason
+      );
+    }
+  } catch (err) {
+    events.sessionResolved({
+      role: "resolver",
+      issue: pr.issue,
+      branch: pr.branch,
+      status: "failed",
+      commits: 0,
+      error: errorMessage(err),
+    });
+    // A CRASHED resolver is a failed merge-phase attempt (#98) — same PR-shaped,
+    // gated:true escalation on exhaustion as the give-up / no-Outcome case.
+    await recordFailedAttempt(
+      { kind: "pr", prNumber: pr.prNumber, gated: true },
+      "land",
+      pr.issue,
+      errorMessage(err)
     );
   } finally {
     lc.done();

--- a/.sandcastle/prompts.test.mts
+++ b/.sandcastle/prompts.test.mts
@@ -16,6 +16,7 @@ import { describe, expect, it } from "vitest";
  *   The test below pins that the prompt file no longer exists.
  */
 const reviewPrompt = readFileSync(new URL("./review-prompt.md", import.meta.url), "utf8");
+const resolvePrompt = readFileSync(new URL("./resolve-prompt.md", import.meta.url), "utf8");
 
 describe("review-prompt.md — Outcome contract (ADR-0011)", () => {
   it("instructs a pass verdict via the <outcome>pass</outcome> tag", () => {
@@ -55,5 +56,41 @@ describe("review-prompt.md — Outcome contract (ADR-0011)", () => {
 describe("merge-prompt.md — deleted for the agent-free Landing (ADR-0012)", () => {
   it("no longer exists: the merge phase is scripted orchestrator code, not a prompt", () => {
     expect(existsSync(new URL("./merge-prompt.md", import.meta.url))).toBe(false);
+  });
+});
+
+describe("resolve-prompt.md — Conflict resolver (ADR-0012, #101)", () => {
+  it("instructs merging origin/main INTO the PR branch (not the other direction)", () => {
+    expect(resolvePrompt).toMatch(/git merge origin\/main/);
+  });
+
+  it("instructs pushing the resolved branch back to the PR", () => {
+    expect(resolvePrompt).toMatch(/git push/);
+  });
+
+  it("instructs the resolver to fix until the suite is green (typecheck + test)", () => {
+    expect(resolvePrompt).toMatch(/pnpm typecheck/);
+    expect(resolvePrompt).toMatch(/pnpm test/);
+  });
+
+  it("reports a pass verdict via the <outcome>pass</outcome> tag", () => {
+    expect(resolvePrompt).toMatch(/<outcome>pass<\/outcome>/);
+  });
+
+  it("reports a give-up verdict with a one-line reason via the outcome tag", () => {
+    expect(resolvePrompt).toMatch(/<outcome>give-up: .*<\/outcome>/);
+  });
+
+  it("contains no dispatch-controlling gh mutations — the orchestrator owns those (ADR-0011)", () => {
+    expect(resolvePrompt).not.toMatch(/--add-label/);
+    expect(resolvePrompt).not.toMatch(/--remove-label/);
+    expect(resolvePrompt).not.toMatch(/gh label create/);
+    expect(resolvePrompt).not.toMatch(/gh pr ready/);
+    expect(resolvePrompt).not.toMatch(/gh pr merge/);
+  });
+
+  it("does not tell the agent to touch the reviewed / ready-for-human labels", () => {
+    expect(resolvePrompt).not.toMatch(/ready-for-human/);
+    expect(resolvePrompt).not.toMatch(/`reviewed`/);
   });
 });

--- a/.sandcastle/resolve-prompt.md
+++ b/.sandcastle/resolve-prompt.md
@@ -1,0 +1,98 @@
+# TASK
+
+A Landing failed for the reviewed PR on branch {{BRANCH}} (issue #{{ISSUE_NUMBER}}: {{ISSUE_TITLE}}).
+
+The PR was green when it was reviewed, so the failure is an **integration
+conflict with `origin/main`** — either a textual `git merge` conflict, or a
+clean merge whose suite is now red because something that landed on `main`
+since the review interacts badly with this branch.
+
+You are an expert engineer resolving that conflict on the PR branch so it can be
+re-reviewed and land.
+
+# CONTEXT
+
+You are already checked out on {{BRANCH}} with the repo installed and built.
+
+Here are the last 10 commits on this branch:
+
+<recent-commits>
+
+!`git log -n 10 --format="%H%n%ad%n%B---" --date=short`
+
+</recent-commits>
+
+<issue>
+
+!`gh issue view {{ISSUE_NUMBER}}`
+
+</issue>
+
+# RESOLUTION PROCESS
+
+1. **Merge `origin/main` INTO this branch** (never the other direction — you fix
+   the PR branch, you do not touch `main`). Fetch first so you integrate the
+   latest `main`:
+
+   ```
+   git fetch origin
+   git merge origin/main --no-edit
+   ```
+
+2. **Resolve any conflicts and integration breakage.** Prefer the intent of both
+   sides: keep this branch's change working while adopting what changed on
+   `main`. If `git merge` reports conflicts, edit the conflicted files, then
+   `git add` them and `git commit` the merge.
+
+3. **Get the suite green:**
+
+   ```
+   pnpm typecheck && pnpm test
+   ```
+
+   Iterate — edit, re-run — until both pass. Keep every original feature,
+   output, and behaviour of the issue's change intact; you are integrating it
+   with `main`, not rewriting it.
+
+4. **Commit your resolution** with a message starting with `RALPH: Resolve -`
+   describing the integration.
+
+5. **Push the resolved branch back to the PR:**
+
+   ```
+   git push
+   ```
+
+# REPORT YOUR OUTCOME
+
+Your job is **resolve + push + verdict**. You do **not** change any
+dispatch-controlling GitHub state — the orchestrator strips the review gate,
+reverts the PR to draft for re-review, and handles escalation, acting on the
+Outcome you report here. Do not run any `gh` command that adds or removes a
+label, marks the PR ready or draft, or merges it.
+
+End your Session with **exactly one** structured Outcome tag on its own line:
+
+- The branch is resolved and pushed — `pnpm typecheck` and `pnpm test` both pass
+  on the merged branch:
+
+  ```
+  <outcome>pass</outcome>
+  ```
+
+  The orchestrator will strip the review gate and revert the PR to draft so it
+  is re-reviewed before it can land again.
+
+- You **cannot resolve the conflict** — after your attempts `pnpm typecheck` or
+  `pnpm test` is still red, or the integration needs a decision beyond a
+  merge-level fix:
+
+  ```
+  <outcome>give-up: <one-line reason></outcome>
+  ```
+
+If you emit no parseable tag, no state changes and the resolution is retried
+against the merge-phase Retry budget.
+
+Once you have pushed and emitted the Outcome tag, output
+<promise>COMPLETE</promise>.


### PR DESCRIPTION
Closes #101.

Replaces the interim "failed Landing → escalate straight to human" path with the **Conflict resolver** (ADR-0012): the agent role dispatched when a Landing fails (textual conflict or red suite after a clean merge).

## Behavior

A failed Landing spends one merge-phase (`land`) Retry-budget attempt, then — below the N=3 threshold — dispatches a resolver Session, keeping the issue **in-flight across the handoff** so no re-Landing races in. In a fresh sandbox on the PR branch, the resolver merges `origin/main` **into** the branch, fixes it green, pushes, and reports an Outcome:

- **pass** → orchestrator strips `reviewed` + reverts the PR to draft (a re-queue, not an escalation), so the resolution re-enters `ready-for-review` and is **re-reviewed before it can land again**
- **give-up / missing Outcome / crash** → spends another `land` attempt

A single shared merge-phase counter bounds the `Landing → resolve → review → Landing` loop, escalating to `ready-for-human` (stripping the gate) on exhaustion — so a defective PR can't ping-pong forever.

## Acceptance criteria

- [x] A failed Landing dispatches a Conflict-resolver Session instead of escalating straight to `ready-for-human`
- [x] A resolver pass puts the PR back in draft without `reviewed`; a subsequent tick dispatches a Reviewer
- [x] A resolver give-up / missing Outcome follows ADR-0011 handling and spends Retry budget; exhaustion escalates to `ready-for-human`
- [x] `resolve-prompt.md` instructs merge-origin/main-into-branch + fix + push + Outcome tag, no dispatch-controlling `gh` mutations; pinned by the prompt test
- [x] Resolver Sessions appear in the Manifest and Live feed under the issue's runId with a distinct `resolve` phase
- [x] `pnpm typecheck` and `pnpm test` green (528 tests)

## How it was built (TDD, test-first)

1. `requeueResolvedPr` (dispatch.mts) — pure PASS re-queue transition, unit-tested
2. `resolve-prompt.md` — Canonical resolver prompt, pinned by `prompts.test.mts`
3. `resolver` role + `resolver-outcome`/`resolver-requeued` events across every exhaustive renderer, with `events.test.mts` coverage
4. `dispatchResolver` + Landing-failure handoff in `main.mts` (`recordFailedAttempt` now returns whether it escalated)

## Notes for review

- **No live end-to-end run.** The resolver path spawns Docker sandboxes + a real Opus agent session against GitHub, not exercisable in-repo — verified via the full test suite, typecheck, and a trace of the in-flight/pool/budget handoff.
- **Model:** the resolver runs on `claude-opus-4-8` (matching Review, since integration is high-stakes). Trivial to change via `MODELS.RESOLUTION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)