### PR TITLE
#102 Self-restart: drain and exit when orchestrator code changes on origin/main; supervisor respawns (ADR-0013)

### DIFF
--- a/.sandcastle/cockpit-core.mts
+++ b/.sandcastle/cockpit-core.mts
@@ -20,6 +20,7 @@
  * it into view state; it renders no event strings of its own.
  */
 import { spawn, type ChildProcess } from "node:child_process";
+import { DRAIN_EXIT_CODE } from "./dispatch.mts";
 import {
   isKnownEventType,
   roleAbbr,
@@ -150,9 +151,10 @@ export function appendLogLine<T>(lines: readonly T[], entry: T, cap: number): T[
 
 /** How a supervised orchestrator child ended, once it is gone. `stopped` is a
  *  clean end (a user Stop, or a rare clean exit); `crashed` is surfaced in the
- *  UI as an error without taking the Cockpit down (ADR-0008). */
+ *  UI as an error without taking the Cockpit down (ADR-0008); `restarting` is a
+ *  self-restart drain (ADR-0013) the supervisor auto-respawns from. */
 export interface ChildExit {
-  readonly status: "stopped" | "crashed";
+  readonly status: "stopped" | "crashed" | "restarting";
   /** A short human line for the status bar / event log. */
   readonly message: string;
 }
@@ -171,11 +173,15 @@ export interface ChildExitInput {
 }
 
 /**
- * Classify a departed orchestrator child as a clean Stop or a crash to surface.
- * The orchestrator loop never self-exits, so any exit the Cockpit did NOT ask
- * for is unexpected: a non-zero code or an unexpected signal is a crash (shown
- * in the UI without killing the Cockpit, per ADR-0008), while a user-requested
- * Stop — or the degenerate clean `exit(0)` — is just "stopped". Pure so the
+ * Classify a departed orchestrator child as a clean Stop, a self-restart drain,
+ * or a crash to surface. A user-requested Stop — or the degenerate clean
+ * `exit(0)` — is "stopped". Otherwise the orchestrator loop self-exits only to
+ * self-restart on upgraded code, which it signals with {@link DRAIN_EXIT_CODE}
+ * (ADR-0013): that is "restarting", and the supervisor auto-respawns it. Any
+ * OTHER unexpected exit — a different non-zero code or an unexpected signal — is
+ * a crash, shown in the UI without killing the Cockpit (ADR-0008) and never
+ * auto-respawned. The user-Stop check comes first so a Stop that happens to
+ * coincide with the drain code never respawns behind the user's back. Pure so the
  * classification is unit-testable without spawning a process.
  */
 export function describeChildExit(input: ChildExitInput): ChildExit {
@@ -183,6 +189,12 @@ export function describeChildExit(input: ChildExitInput): ChildExit {
     return input.forced
       ? { status: "stopped", message: "orchestrator force-killed (ignored stop)" }
       : { status: "stopped", message: "orchestrator stopped" };
+  }
+  if (input.code === DRAIN_EXIT_CODE) {
+    return {
+      status: "restarting",
+      message: `orchestrator restarting on new code (drain exit code ${DRAIN_EXIT_CODE})`,
+    };
   }
   if (input.code !== null && input.code !== 0) {
     return { status: "crashed", message: `orchestrator crashed (exit code ${input.code})` };

--- a/.sandcastle/cockpit-core.test.mts
+++ b/.sandcastle/cockpit-core.test.mts
@@ -20,6 +20,7 @@ import {
   type InputKey,
   type OrchestratorHandlers,
 } from "./cockpit-core.mts";
+import { DRAIN_EXIT_CODE } from "./dispatch.mts";
 import { formatEventLog, type OrchestratorEvent } from "./events.mts";
 import type { PrunePlan } from "./prune-plan.mts";
 
@@ -576,6 +577,29 @@ describe("describeChildExit", () => {
       status: "stopped",
       message: "orchestrator exited",
     });
+  });
+
+  it("classifies the drain exit code as restarting (auto-respawn), not a crash", () => {
+    // A self-restart drain exits with DRAIN_EXIT_CODE (ADR-0013, #102). The
+    // supervisor must recognize it as `restarting` so it auto-respawns on the new
+    // code — NOT `crashed` (which is surfaced but never respawned).
+    expect(
+      describeChildExit({ code: DRAIN_EXIT_CODE, signal: null, stoppedByUser: false })
+    ).toEqual({
+      status: "restarting",
+      message: `orchestrator restarting on new code (drain exit code ${DRAIN_EXIT_CODE})`,
+    });
+  });
+
+  it("does not restart when the user's Stop coincides with the drain code", () => {
+    // A user Stop wins: they asked it to stop, so even a drain-coded exit must not
+    // auto-respawn behind their back.
+    expect(describeChildExit({ code: DRAIN_EXIT_CODE, signal: null, stoppedByUser: true })).toEqual(
+      {
+        status: "stopped",
+        message: "orchestrator stopped",
+      }
+    );
   });
 
   it("distinguishes a forced kill (unresponsive to SIGTERM) from a clean stop", () => {

--- a/.sandcastle/cockpit.tsx
+++ b/.sandcastle/cockpit.tsx
@@ -111,8 +111,9 @@ const SESSIONS_WINDOW_LABEL = windowLabelOf(SESSIONS_WINDOW);
 
 /** The Live tab's supervised-child status. Launches `idle`; `running` while a
  *  child is alive; `stopped` after a clean Stop/exit; `crashed` after an
- *  unexpected exit (surfaced, never fatal to the Cockpit). */
-type ChildStatus = "idle" | "running" | "stopped" | "crashed";
+ *  unexpected exit (surfaced, never fatal to the Cockpit); `restarting` briefly
+ *  while a self-restart drain (ADR-0013) respawns the child on new code. */
+type ChildStatus = "idle" | "running" | "stopped" | "crashed" | "restarting";
 
 /** One rendered line in the scrolling event log, with optional colour/dim. */
 interface LogEntry {
@@ -196,6 +197,8 @@ function statusColor(status: ChildStatus): string {
       return "red";
     case "stopped":
       return "yellow";
+    case "restarting":
+      return "cyan";
     case "idle":
       return "gray";
   }
@@ -472,6 +475,10 @@ function Cockpit(): React.ReactElement {
   // the async stdout/exit handlers always see the current child without stale
   // closures and toggling it never triggers a re-render on its own.
   const supervisorRef = useRef<Supervisor | null>(null);
+  // Holds the latest `start` so the exit handler can respawn the child after a
+  // self-restart drain (ADR-0013) without `start` closing over a stale version of
+  // itself. Set from an effect below, once `start` is defined.
+  const startRef = useRef<() => void>(() => {});
   // Guards prune discovery against re-entrancy: the lazy-load effect and the `r`
   // key can both fire while a discovery microtask is already pending.
   const maintLoadingRef = useRef(false);
@@ -550,9 +557,13 @@ function Cockpit(): React.ReactElement {
         setStatus(exitStatus);
         setStatusMessage(message);
         pushLog({
-          text: `${exitStatus === "crashed" ? "✗" : "■"} ${message}`,
-          color: exitStatus === "crashed" ? "red" : "yellow",
+          text: `${exitStatus === "crashed" ? "✗" : exitStatus === "restarting" ? "⟳" : "■"} ${message}`,
+          color: exitStatus === "crashed" ? "red" : exitStatus === "restarting" ? "cyan" : "yellow",
         });
+        // ADR-0013: a self-restart drain auto-respawns the child on the new code —
+        // the supervisor's job, not the human's (an unattended loop must follow
+        // its own upgrades). A `crashed` exit is deliberately NOT respawned.
+        if (exitStatus === "restarting") startRef.current();
       },
       onSpawnError: (message) => {
         supervisorRef.current = null;
@@ -562,6 +573,12 @@ function Cockpit(): React.ReactElement {
       },
     });
   }, [pushLog]);
+
+  // Keep the respawn hook pointing at the latest `start` so the exit handler's
+  // self-restart (ADR-0013) never calls a stale closure.
+  useEffect(() => {
+    startRef.current = start;
+  }, [start]);
 
   /** Stop the running orchestrator child (no-op if none). */
   const stop = useCallback(() => {

--- a/.sandcastle/dispatch.mts
+++ b/.sandcastle/dispatch.mts
@@ -28,6 +28,58 @@ export const POLL_INTERVAL_MS = 60_000;
  */
 export const BASE_BRANCH = "origin/main";
 
+/**
+ * The distinct exit code a self-restarting orchestrator exits with after it has
+ * drained (ADR-0013, #102). It must NOT collide with a clean exit (`0`), a
+ * generic crash (`1`), or a signal-derived code (e.g. `130` for SIGINT), because
+ * the Cockpit supervisor and the headless wrapper key on exactly this code to
+ * decide **auto-restart** vs. leave-stopped: a drain code means "the code
+ * upstream changed, respawn on it"; anything else is a stop or a crash. `75` is
+ * `EX_TEMPFAIL` from sysexits.h — "temporary failure, retry" — which reads
+ * exactly right for a benign drain-and-respawn.
+ */
+export const DRAIN_EXIT_CODE = 75;
+
+/**
+ * Whether an exited orchestrator child should be **restarted** rather than left
+ * stopped — the single predicate the supervisor and the headless wrapper share
+ * so the restart contract lives in one place. True only for {@link
+ * DRAIN_EXIT_CODE}; a `null` code (killed by signal) and every other numeric
+ * code are a stop/crash, not a restart. Pure so the contract is unit-testable.
+ */
+export function shouldRestart(code: number | null): boolean {
+  return code === DRAIN_EXIT_CODE;
+}
+
+/**
+ * Decide whether a fetched `origin/main` commit staled the running orchestrator
+ * — i.e. whether any path it changed is the orchestrator's **own code** (ADR-0013,
+ * #102). The orchestrator's `.mts`/`.tsx` code is loaded once at process start,
+ * while prompts are re-read per Session from branch worktrees, so only a change
+ * to the loaded code can wedge the loop (old code driving new prompts). A path
+ * counts as own-code when it is a TypeScript source file under `.sandcastle/`
+ * — **excluding** test files (a test-only commit never wedges the running loop)
+ * and prompt/doc `.md` files (picked up per-Session, not at process start). Every
+ * other path — site/product code, docs, build/config — leaves the process valid,
+ * because Sessions already pick up fresh product code via `origin/main`-based
+ * worktrees; only the orchestrator process itself goes stale (ADR-0013).
+ *
+ * Pure (paths in, boolean out) so the drain trigger is unit-testable without a
+ * live fetch or git diff — `main.mts` supplies the changed-path list from a
+ * `git diff --name-only <old> <new>` against the freshly fetched ref.
+ */
+export function orchestratorCodeChanged(changedPaths: readonly string[]): boolean {
+  return changedPaths.some(isOrchestratorSourcePath);
+}
+
+/** True for a TypeScript source file under `.sandcastle/` that is loaded into the
+ *  orchestrator process at start — not a test file, not a prompt/doc. */
+function isOrchestratorSourcePath(path: string): boolean {
+  if (!path.startsWith(".sandcastle/")) return false;
+  if (/\.test\.(mts|ts|tsx)$/.test(path)) return false;
+  return /\.(mts|ts|tsx)$/.test(path);
+}
+
 /** The install+build hook every sandbox runs before its work. Frozen-lockfile
  *  because this repo is pnpm-only — a plain install would resolve a competing
  *  lockfile (see main.mts). */

--- a/.sandcastle/dispatch.test.mts
+++ b/.sandcastle/dispatch.test.mts
@@ -3,11 +3,14 @@ import { describe, expect, it } from "vitest";
 
 import {
   BASE_BRANCH,
+  DRAIN_EXIT_CODE,
   NOOP_IMPLEMENTER_COMMENT,
   POOL_SIZE,
   POLL_INTERVAL_MS,
   RETRY_BUDGET_N,
   budgetExhaustedComment,
+  orchestratorCodeChanged,
+  shouldRestart,
   createInflight,
   createRetryBudget,
   escalateBudgetExhausted,
@@ -1001,6 +1004,68 @@ describe("landingSandboxSpec — validate the merge against origin/main (ADR-001
   });
 });
 
+describe("self-restart drain decision (ADR-0013, #102)", () => {
+  describe("orchestratorCodeChanged", () => {
+    it("triggers on a changed orchestrator source file", () => {
+      // The orchestrator's own .mts/.tsx code is loaded once at process start, so
+      // a fetched origin/main commit that changes it makes the running process
+      // stale — it must drain and restart on the new code.
+      expect(orchestratorCodeChanged([".sandcastle/main.mts"])).toBe(true);
+      expect(orchestratorCodeChanged([".sandcastle/dispatch.mts"])).toBe(true);
+      expect(orchestratorCodeChanged([".sandcastle/cockpit.tsx"])).toBe(true);
+      expect(orchestratorCodeChanged([".sandcastle/tsconfig.json"])).toBe(false);
+    });
+
+    it("ignores prompt changes — prompts are read per-Session from worktrees", () => {
+      // A prompt (.md) change is picked up by the next Session from its branch
+      // worktree; it does NOT stale the running process, so it must not restart.
+      expect(orchestratorCodeChanged([".sandcastle/plan-prompt.md"])).toBe(false);
+      expect(orchestratorCodeChanged([".sandcastle/review-prompt.md"])).toBe(false);
+    });
+
+    it("ignores test files — a test-only commit never wedges the running loop", () => {
+      expect(orchestratorCodeChanged([".sandcastle/dispatch.test.mts"])).toBe(false);
+      expect(orchestratorCodeChanged([".sandcastle/cockpit-core.test.mts"])).toBe(false);
+    });
+
+    it("ignores unrelated site / product / docs code", () => {
+      // Sessions pick up fresh product code via origin/main-based worktrees, so
+      // only the orchestrator process itself goes stale (ADR-0013).
+      expect(orchestratorCodeChanged(["app/home/page.tsx"])).toBe(false);
+      expect(orchestratorCodeChanged(["lib/gameCatalog.ts"])).toBe(false);
+      expect(orchestratorCodeChanged(["docs/adr/0013-origin-tracking.md"])).toBe(false);
+      expect(orchestratorCodeChanged(["package.json"])).toBe(false);
+    });
+
+    it("triggers when any one path in a mixed commit is orchestrator code", () => {
+      expect(orchestratorCodeChanged(["app/home/page.tsx", ".sandcastle/events.mts"])).toBe(true);
+    });
+
+    it("does not trigger on an empty change set (SHA unmoved / no diff)", () => {
+      expect(orchestratorCodeChanged([])).toBe(false);
+    });
+  });
+
+  describe("DRAIN_EXIT_CODE / shouldRestart", () => {
+    it("is a distinct non-zero code, separable from clean exit and crashes", () => {
+      // The restart signal must not collide with a clean exit (0), a generic
+      // crash (1), or a SIGINT (130) — the supervisor and headless wrapper key
+      // on exactly this code to decide auto-restart vs. stop.
+      expect(DRAIN_EXIT_CODE).not.toBe(0);
+      expect(DRAIN_EXIT_CODE).not.toBe(1);
+      expect(DRAIN_EXIT_CODE).not.toBe(130);
+    });
+
+    it("shouldRestart is true only for the drain exit code", () => {
+      expect(shouldRestart(DRAIN_EXIT_CODE)).toBe(true);
+      expect(shouldRestart(0)).toBe(false);
+      expect(shouldRestart(1)).toBe(false);
+      expect(shouldRestart(130)).toBe(false);
+      expect(shouldRestart(null)).toBe(false);
+    });
+  });
+});
+
 const mainSource = readFileSync(new URL("./main.mts", import.meta.url), "utf8");
 
 describe("main.mts — origin-tracking (ADR-0013, #100)", () => {
@@ -1032,14 +1097,56 @@ describe("main.mts — origin-tracking (ADR-0013, #100)", () => {
   });
 });
 
+describe("main.mts — self-restart on upgrade (ADR-0013, #102)", () => {
+  it("uses the pure orchestratorCodeChanged decision on the fetched diff", () => {
+    // The drain trigger is the pure decision from dispatch.mts, not ad-hoc string
+    // matching inlined in the loop.
+    expect(mainSource).toMatch(/orchestratorCodeChanged\(/);
+  });
+
+  it("reads origin/main and diffs it by name to find what a fetch changed", () => {
+    // Detection compares the last-seen origin/main SHA to the freshly-fetched one
+    // and asks git which paths moved — never touching local main or the worktree.
+    expect(mainSource).toMatch(/"rev-parse",\s*"origin\/main"/);
+    expect(mainSource).toMatch(/"diff",\s*"--name-only"/);
+  });
+
+  it("detects the upgrade after the fetch and before dispatching new work", () => {
+    // The check must run on the fresh refs (post-fetch) and gate dispatch, so no
+    // new work starts on stale code the tick an upgrade lands.
+    const fetchIdx = mainSource.indexOf("await fetchOrigin();");
+    const detectIdx = mainSource.indexOf("detectOrchestratorUpgrade(lastMainSha)");
+    const dispatchIdx = mainSource.indexOf("[readyForAgent, prs] = await Promise.all(");
+    expect(fetchIdx).toBeGreaterThan(-1);
+    expect(detectIdx).toBeGreaterThan(fetchIdx);
+    expect(detectIdx).toBeLessThan(dispatchIdx);
+  });
+
+  it("begins the drain by flagging it and emitting drainStarted", () => {
+    // Flipping `draining` is what stops future ticks from dispatching; the event
+    // makes the drain visible in the Live feed (ADR-0013).
+    expect(mainSource).toMatch(/draining = true/);
+    expect(mainSource).toMatch(/events\.drainStarted\(/);
+  });
+
+  it("exits with DRAIN_EXIT_CODE once the In-flight set empties, emitting drainComplete", () => {
+    // In-flight Sessions run to completion (drain), THEN the process exits with the
+    // distinct restart code the supervisor / headless wrapper key on.
+    expect(mainSource).toMatch(/events\.drainComplete\(/);
+    expect(mainSource).toMatch(/process\.exit\(DRAIN_EXIT_CODE\)/);
+    expect(mainSource).toMatch(/draining && inflight\.size\(\) === 0/);
+  });
+});
+
 describe("main.mts — persistent shared-pool orchestrator (ADR-0006)", () => {
   it("drops the discrete MAX_ITERATIONS for-loop", () => {
     expect(mainSource).not.toMatch(/MAX_ITERATIONS/);
     expect(mainSource).not.toMatch(/MAX_PARALLEL/);
   });
 
-  it("runs as a persistent loop (never self-exits)", () => {
-    // A persistent Poll tick loop, not a bounded `for (let iteration ...)`.
+  it("runs as a persistent loop (self-exits only to self-restart)", () => {
+    // A persistent Poll tick loop, not a bounded `for (let iteration ...)`. It
+    // self-exits only for the ADR-0013 self-restart drain (DRAIN_EXIT_CODE).
     expect(mainSource).toMatch(/for\s*\(\s*;;\s*\)|while\s*\(\s*true\s*\)/);
   });
 
@@ -1256,5 +1363,38 @@ describe("main.mts — Retry budget (ADR-0011, #98)", () => {
     expect(clearIdx).toBeGreaterThan(-1);
     expect(escalateIdx).toBeGreaterThan(-1);
     expect(clearIdx).toBeLessThan(escalateIdx);
+  });
+});
+
+describe("run.mts — headless restart wrapper (ADR-0013, #102)", () => {
+  // Read lazily so a missing wrapper fails only these tests, not the whole file.
+  const runSource = (): string => readFileSync(new URL("./run.mts", import.meta.url), "utf8");
+
+  it("spawns the orchestrator entrypoint (main.mts)", () => {
+    expect(runSource()).toMatch(/main\.mts/);
+  });
+
+  it("restarts only via the shared shouldRestart contract, not a hard-coded number", () => {
+    // The wrapper and the Cockpit supervisor share one restart predicate so the
+    // headless and supervised restart behaviours can never drift.
+    expect(runSource()).toMatch(/shouldRestart\(/);
+    expect(runSource()).toMatch(/from\s+["']\.\/dispatch\.mts["']/);
+  });
+
+  it("exits with the child's own code on any non-restart exit (stop on anything else)", () => {
+    // Only a drain code restarts; a clean stop or a crash leaves the wrapper for
+    // good, propagating the child's exit code.
+    expect(runSource()).toMatch(/process\.exit\(/);
+  });
+});
+
+describe("package.json — headless sandcastle restarts on drain (ADR-0013, #102)", () => {
+  it("routes the sandcastle script through the restart wrapper", () => {
+    const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
+      scripts: Record<string, string>;
+    };
+    expect(pkg.scripts.sandcastle).toMatch(/run\.mts/);
+    // The one-time image build still precedes the loop (the wrapper only loops main.mts).
+    expect(pkg.scripts.sandcastle).toMatch(/docker build-image/);
   });
 });

--- a/.sandcastle/events.mts
+++ b/.sandcastle/events.mts
@@ -234,6 +234,25 @@ interface BudgetExhaustedEvent extends BaseEvent {
   readonly attempts: number;
 }
 
+/** The orchestrator's own code changed on the freshly-fetched `origin/main`, so
+ *  it is **draining** to self-restart on the new code (ADR-0013, #102): it stops
+ *  dispatching and lets `inflight` in-flight Session(s) finish before exiting.
+ *  `commit` is the short `origin/main` SHA the process will restart on. */
+interface DrainStartedEvent extends BaseEvent {
+  readonly type: "drain-started";
+  readonly commit: string;
+  readonly inflight: number;
+}
+
+/** The self-restart drain finished — the In-flight set emptied — so the
+ *  orchestrator is exiting with {@link DRAIN_EXIT_CODE} for the supervisor /
+ *  headless wrapper to respawn it on the new code (ADR-0013, #102). `commit` is
+ *  the short `origin/main` SHA it restarts on. */
+interface DrainCompleteEvent extends BaseEvent {
+  readonly type: "drain-complete";
+  readonly commit: string;
+}
+
 /**
  * The discriminated union of every orchestrator event. `type` is the single
  * discriminator the renderers switch on; the contract the Cockpit consumes.
@@ -260,7 +279,9 @@ export type OrchestratorEvent =
   | LandingLandedEvent
   | LandingFailedEvent
   | AttemptFailedEvent
-  | BudgetExhaustedEvent;
+  | BudgetExhaustedEvent
+  | DrainStartedEvent
+  | DrainCompleteEvent;
 
 /** Which stdout stream a prose-rendered event belongs on (preserves the
  *  existing stdout/stderr split so headless output is unchanged). */
@@ -332,6 +353,10 @@ export function formatEventProse(event: OrchestratorEvent): string | null {
       return `  ⚠ #${event.issue} ${event.phase} attempt ${event.attempt}/${event.limit} failed — retrying.`;
     case "budget-exhausted":
       return `  ⚠ #${event.issue} ${event.phase} Retry budget exhausted after ${event.attempts} attempts — escalated to ready-for-human.`;
+    case "drain-started":
+      return `  ⟳ orchestrator code changed on origin/main (${event.commit}) — draining ${event.inflight} in-flight Session(s) before restart.`;
+    case "drain-complete":
+      return `  ⟳ drain complete — exiting to restart on origin/main (${event.commit}).`;
   }
 }
 
@@ -459,6 +484,10 @@ export function formatEventLog(event: OrchestratorEvent): string {
       return `⚠ #${event.issue} ${event.phase} attempt ${event.attempt}/${event.limit} failed`;
     case "budget-exhausted":
       return `⚠ #${event.issue} ${event.phase} budget exhausted · ${event.attempts} attempts · escalated to ready-for-human`;
+    case "drain-started":
+      return `⟳ code changed (${event.commit}) · draining ${event.inflight} in-flight · will restart`;
+    case "drain-complete":
+      return `⟳ drain complete · restarting on ${event.commit}`;
     default: {
       // Exhaustiveness guard: adding a new OrchestratorEvent type without a log
       // line here is a compile error, so the Live log can never silently omit one.
@@ -491,6 +520,10 @@ export function eventSeverity(event: OrchestratorEvent): EventSeverity {
     case "planner-no-plan":
     case "attempt-failed":
     case "budget-exhausted":
+    // The self-restart drain is benign by design (ADR-0013), but a notable state
+    // transition the Live tab should surface — warn (yellow), not a failure.
+    case "drain-started":
+    case "drain-complete":
       return "warn";
     case "reviewer-outcome":
     case "resolver-outcome":
@@ -546,6 +579,8 @@ const EVENT_TYPE_TAGS: Record<OrchestratorEvent["type"], true> = {
   "landing-failed": true,
   "attempt-failed": true,
   "budget-exhausted": true,
+  "drain-started": true,
+  "drain-complete": true,
 };
 
 /** Every `type` discriminator the orchestrator can emit, derived from the union
@@ -654,6 +689,12 @@ export interface OrchestratorEvents {
   /** The Retry budget for `issue`+`phase` was exhausted after `attempts` failed
    *  attempts — the item was escalated to `ready-for-human` (#98). */
   budgetExhausted(issue: number, phase: string, attempts: number): void;
+  /** The orchestrator's own code changed on origin/main — draining `inflight`
+   *  Session(s) before self-restarting on `commit` (ADR-0013, #102). */
+  drainStarted(commit: string, inflight: number): void;
+  /** The self-restart drain finished (In-flight emptied) — exiting to restart on
+   *  `commit` (ADR-0013, #102). */
+  drainComplete(commit: string): void;
 }
 
 /** Options for {@link createEvents}; every dependency is injectable for tests. */
@@ -740,5 +781,8 @@ export function createEvents(opts: CreateEventsOptions = {}): OrchestratorEvents
       emit({ type: "attempt-failed", issue, phase, attempt, limit, ts: stamp() }),
     budgetExhausted: (issue, phase, attempts) =>
       emit({ type: "budget-exhausted", issue, phase, attempts, ts: stamp() }),
+    drainStarted: (commit, inflight) =>
+      emit({ type: "drain-started", commit, inflight, ts: stamp() }),
+    drainComplete: (commit) => emit({ type: "drain-complete", commit, ts: stamp() }),
   };
 }

--- a/.sandcastle/events.test.mts
+++ b/.sandcastle/events.test.mts
@@ -5,6 +5,7 @@ import {
   EVENT_TYPES,
   eventSeverity,
   eventStream,
+  formatEventLog,
   formatEventNdjson,
   formatEventProse,
   isKnownEventType,
@@ -663,6 +664,8 @@ describe("EVENT_TYPES / isKnownEventType", () => {
     "landing-failed",
     "attempt-failed",
     "budget-exhausted",
+    "drain-started",
+    "drain-complete",
   ];
 
   it("contains exactly every orchestrator event type, no more, no fewer", () => {
@@ -715,6 +718,15 @@ describe("eventSeverity", () => {
     ).toBe("warn");
   });
 
+  it("classifies the self-restart drain as warn (notable but benign)", () => {
+    // The drain/restart is benign by design (ADR-0013) but a notable state
+    // transition the Live tab should surface — warn (yellow), not failure/normal.
+    expect(eventSeverity(evt({ type: "drain-started", commit: "abc1234", inflight: 2 }))).toBe(
+      "warn"
+    );
+    expect(eventSeverity(evt({ type: "drain-complete", commit: "abc1234" }))).toBe("warn");
+  });
+
   it("classifies progress events (incl. a successful resolution) as normal", () => {
     expect(eventSeverity(evt({ type: "tick", free: 1, poolSize: 10, inflight: 0 }))).toBe("normal");
     expect(eventSeverity(evt({ type: "planner-emitted", count: 1 }))).toBe("normal");
@@ -737,5 +749,66 @@ describe("eventSeverity", () => {
         })
       )
     ).toBe("normal");
+  });
+});
+
+// ── drain events: the Live feed shows the self-restart (ADR-0013, #102) ──────
+
+describe("drain events", () => {
+  it("prose renders the drain start and completion on stdout", () => {
+    // The Live feed shows the drain throughout: which upstream commit staled the
+    // process, how many Sessions must finish, then the exit-to-restart.
+    expect(formatEventProse(evt({ type: "drain-started", commit: "abc1234", inflight: 2 }))).toBe(
+      "  ⟳ orchestrator code changed on origin/main (abc1234) — draining 2 in-flight Session(s) before restart."
+    );
+    expect(formatEventProse(evt({ type: "drain-complete", commit: "abc1234" }))).toBe(
+      "  ⟳ drain complete — exiting to restart on origin/main (abc1234)."
+    );
+    expect(eventStream(evt({ type: "drain-started", commit: "abc1234", inflight: 2 }))).toBe(
+      "stdout"
+    );
+    expect(eventStream(evt({ type: "drain-complete", commit: "abc1234" }))).toBe("stdout");
+  });
+
+  it("renders one compact Cockpit log line per drain event", () => {
+    expect(formatEventLog(evt({ type: "drain-started", commit: "abc1234", inflight: 2 }))).toBe(
+      "⟳ code changed (abc1234) · draining 2 in-flight · will restart"
+    );
+    expect(formatEventLog(evt({ type: "drain-complete", commit: "abc1234" }))).toBe(
+      "⟳ drain complete · restarting on abc1234"
+    );
+  });
+
+  it("the emitter stamps and routes both drain events", () => {
+    const out = vi.fn();
+    const err = vi.fn();
+    const events = createEvents({
+      format: "prose",
+      now: () => new Date("2026-07-04T10:00:00.000Z"),
+      out,
+      err,
+    });
+    events.drainStarted("abc1234", 2);
+    events.drainComplete("abc1234");
+    expect(err).not.toHaveBeenCalled();
+    expect(out).toHaveBeenNthCalledWith(
+      1,
+      "  ⟳ orchestrator code changed on origin/main (abc1234) — draining 2 in-flight Session(s) before restart."
+    );
+    expect(out).toHaveBeenNthCalledWith(
+      2,
+      "  ⟳ drain complete — exiting to restart on origin/main (abc1234)."
+    );
+  });
+
+  it("ndjson carries the discriminator + payload for both drain events", () => {
+    const started = JSON.parse(
+      formatEventNdjson(evt({ type: "drain-started", commit: "abc1234", inflight: 2 }))
+    ) as Record<string, unknown>;
+    expect(started).toMatchObject({ type: "drain-started", commit: "abc1234", inflight: 2 });
+    const done = JSON.parse(
+      formatEventNdjson(evt({ type: "drain-complete", commit: "abc1234" }))
+    ) as Record<string, unknown>;
+    expect(done).toMatchObject({ type: "drain-complete", commit: "abc1234" });
   });
 });

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -6,6 +6,7 @@ import {
   createInflight,
   createPool,
   createRetryBudget,
+  DRAIN_EXIT_CODE,
   escalateBudgetExhausted,
   filterReadyForAgent,
   filterReadyForMerge,
@@ -16,6 +17,7 @@ import {
   isBudgetExhausted,
   issueFromBranch,
   landingSandboxSpec,
+  orchestratorCodeChanged,
   parseOutcome,
   pickImplementers,
   pickPrs,
@@ -160,6 +162,61 @@ async function fetchOrigin(): Promise<{ ok: true } | { ok: false; error: string 
   } catch (err) {
     return { ok: false, error: errorMessage(err) };
   }
+}
+
+/**
+ * The current `origin/main` commit SHA on the host (the remote-tracking ref
+ * {@link fetchOrigin} refreshes), or `null` when it can't be read. Seeded once at
+ * startup and re-read after each fetch: a change means the fetch advanced the ref
+ * (ADR-0013, #102). Read-only — like the bare fetch, it never touches local main.
+ */
+async function originMainSha(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["rev-parse", "origin/main"], {
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect whether a fetch advanced `origin/main` onto a commit that changed the
+ * orchestrator's OWN code — the self-restart drain trigger (ADR-0013, #102). The
+ * orchestrator's `.mts`/`.tsx` code is loaded once at process start, so a change
+ * to it staled the running process (old code driving new prompts, which wedges
+ * the loop). Compares `lastSha` to the freshly-fetched SHA and asks git which
+ * paths moved (`git diff --name-only`), then applies the pure
+ * {@link orchestratorCodeChanged} classifier. Returns the new SHA (so the caller
+ * advances its last-seen marker even for a benign product-only change) and
+ * whether it staled us; `null` when the ref is unreadable or unchanged. A first
+ * detection with no `lastSha` records the ref without restarting (nothing to
+ * diff against).
+ */
+async function detectOrchestratorUpgrade(
+  lastSha: string | null
+): Promise<{ sha: string; shortSha: string; codeChanged: boolean } | null> {
+  const newSha = await originMainSha();
+  if (newSha === null || newSha === lastSha) return null;
+  let codeChanged = false;
+  if (lastSha !== null) {
+    try {
+      const { stdout } = await execFileAsync("git", ["diff", "--name-only", lastSha, newSha], {
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      const paths = stdout
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0);
+      codeChanged = orchestratorCodeChanged(paths);
+    } catch {
+      // A diff failure must not restart on a guess — treat as no orchestrator
+      // change; the next fetch re-detects against the now-advanced marker.
+      codeChanged = false;
+    }
+  }
+  return { sha: newSha, shortSha: newSha.slice(0, 7), codeChanged };
 }
 
 /**
@@ -845,11 +902,26 @@ async function runPlanner(): Promise<EmittedIssue[]> {
   return issues;
 }
 
+// Self-restart on upgrade (ADR-0013, #102). The orchestrator's own code is loaded
+// once here at process start, so a later fetch that advances origin/main onto a
+// commit touching that code makes the running process stale. We track the SHA the
+// code was loaded from; when a fetch moves it onto our own code, we DRAIN — stop
+// dispatching, let in-flight Sessions finish — then exit with DRAIN_EXIT_CODE for
+// the supervisor (Cockpit) / headless wrapper to respawn on the new code. Seeded
+// here so the first detected change diffs against startup.
+let lastMainSha = await originMainSha();
+let draining = false;
+let drainCommit = "";
+
 for (;;) {
   const free = pool.free();
   events.tick(free, POOL_SIZE, inflight.size());
 
-  if (!shouldQueryBuckets(free)) {
+  if (draining) {
+    // Draining: dispatch nothing more. In-flight Sessions (fire-and-forget) keep
+    // resolving across ticks; the exit gate at the end of the loop fires the
+    // moment the In-flight set empties.
+  } else if (!shouldQueryBuckets(free)) {
     events.poolFull();
   } else {
     // ADR-0013: fetch origin once per dispatching tick so new branches fork,
@@ -858,8 +930,19 @@ for (;;) {
     // the next tick re-fetches. (Bare fetch: remote-tracking refs only, never the
     // human's local main or working tree.)
     const fetched = await fetchOrigin();
+    // ADR-0013 self-restart: with fresh refs in hand, check whether the fetch
+    // advanced origin/main onto a commit touching our OWN code before dispatching
+    // anything — so no new work starts on stale code the tick an upgrade lands.
+    const upgrade = fetched.ok ? await detectOrchestratorUpgrade(lastMainSha) : null;
+    if (upgrade !== null) lastMainSha = upgrade.sha;
     if (!fetched.ok) {
       events.fetchFailed(fetched.error);
+    } else if (upgrade?.codeChanged) {
+      // Our own code changed upstream — begin the drain. Flipping `draining` stops
+      // every future tick from dispatching; the event surfaces it in the Live feed.
+      draining = true;
+      drainCommit = upgrade.shortSha;
+      events.drainStarted(drainCommit, inflight.size());
     } else {
       // One ready-for-agent issue query + one PR query feeds all three buckets:
       // the PR list is split into ready-for-merge / ready-for-review, and its
@@ -938,6 +1021,18 @@ for (;;) {
         events.plannerSkipped();
       }
     }
+  }
+
+  // ADR-0013 self-restart exit gate: once draining, leave the moment the In-flight
+  // set empties — every dispatched Session has run to completion — exiting with the
+  // distinct DRAIN_EXIT_CODE the supervisor / headless wrapper recognize to respawn
+  // on the new code. Checked here (not only at the top) so a drain that begins with
+  // nothing in flight exits this same tick rather than idling a full interval. The
+  // restart is benign by design: the empty In-flight set is accurate, the Plan
+  // cache re-plans once, and Retry budgets reset (ADR-0006/0010/0011).
+  if (draining && inflight.size() === 0) {
+    events.drainComplete(drainCommit);
+    process.exit(DRAIN_EXIT_CODE);
   }
 
   await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));

--- a/.sandcastle/run.mts
+++ b/.sandcastle/run.mts
@@ -1,0 +1,63 @@
+/**
+ * Headless restart wrapper for the orchestrator (self-restart on upgrade,
+ * ADR-0013, #102). `pnpm sandcastle` runs the orchestrator with no Cockpit
+ * supervising it, so the shell-level restart the Cockpit gives supervised runs
+ * lives here instead: spawn `main.mts`, and when it exits with the drain code —
+ * meaning its own code changed on `origin/main` and it drained to restart — spawn
+ * it again on the new code. Any OTHER exit (a clean stop, a crash, a Ctrl-C) ends
+ * the wrapper, propagating the child's exit code.
+ *
+ * The restart contract is the SAME {@link shouldRestart} the Cockpit supervisor
+ * uses ({@link import("./cockpit-core.mts").describeChildExit}), so the headless
+ * and supervised restart behaviours can never drift. This wrapper is the thin
+ * imperative layer only — the decision is the pure predicate in `dispatch.mts`.
+ */
+import { spawn } from "node:child_process";
+import { DRAIN_EXIT_CODE, shouldRestart } from "./dispatch.mts";
+
+/** Absolute path to the orchestrator entrypoint — resolved off this module's URL
+ *  so the wrapper works regardless of the process's cwd. */
+const ENTRY = new URL("./main.mts", import.meta.url).pathname;
+
+/**
+ * Run the orchestrator once, inheriting stdio so its headless prose feed streams
+ * straight to the terminal. Resolves with the exit code the wrapper decides on:
+ * the child's own numeric code, or — when a signal killed it (Ctrl-C, a kill) —
+ * a non-zero code so the wrapper stops rather than restarts. Forwards SIGINT /
+ * SIGTERM to the child so a Ctrl-C stops the orchestrator cleanly instead of
+ * orphaning it.
+ */
+function runOrchestrator(): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn("tsx", [ENTRY], { stdio: "inherit" });
+    const forward = (signal: NodeJS.Signals) => {
+      if (child.exitCode === null) child.kill(signal);
+    };
+    process.on("SIGINT", forward);
+    process.on("SIGTERM", forward);
+    const cleanup = () => {
+      process.off("SIGINT", forward);
+      process.off("SIGTERM", forward);
+    };
+    child.on("exit", (code, signal) => {
+      cleanup();
+      // A signal-killed child reports code === null — treat as a non-restart stop
+      // (128 + is the conventional signal-exit encoding; any non-drain code stops).
+      resolve(code ?? (signal ? 130 : 0));
+    });
+    child.on("error", (err) => {
+      cleanup();
+      console.error(`failed to start orchestrator: ${err.message}`);
+      resolve(1);
+    });
+  });
+}
+
+for (;;) {
+  const code = await runOrchestrator();
+  if (!shouldRestart(code)) process.exit(code);
+  // Drain exit: the orchestrator's code changed upstream and it drained cleanly.
+  console.log(
+    `\n↻ orchestrator drained to restart (exit ${DRAIN_EXIT_CODE}) — relaunching on the new code…\n`
+  );
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "sandcastle:build-image": "sandcastle docker build-image",
-    "sandcastle": "sandcastle docker build-image && tsx .sandcastle/main.mts",
+    "sandcastle": "sandcastle docker build-image && tsx .sandcastle/run.mts",
     "sandcastle:browse": "tsx .sandcastle/session-browser.tsx",
     "sandcastle:cockpit": "tsx .sandcastle/cockpit.tsx",
     "sandcastle:prune": "tsx .sandcastle/prune.mts",


### PR DESCRIPTION
Closes #102. Implements ADR-0013 self-restart (builds on the per-tick fetch, #100).

## What & why

Prompts are read per-Session from branch worktrees, but the orchestrator's own `.mts`/`.tsx` code is loaded once at process start — so an old process driving new prompts can wedge the loop. When a per-tick fetch advances `origin/main` onto a commit touching the orchestrator's **own** code, the loop now **drains** (stops dispatching, lets in-flight Sessions finish) and exits with a distinct code that both the Cockpit supervisor and a headless wrapper auto-restart on. The restart is benign by design: the empty In-flight set is accurate, the Plan cache re-plans once, Retry budgets reset.

## Changes (built test-first, vertical slices)

- **`dispatch.mts`** — pure `orchestratorCodeChanged(paths)` (`.sandcastle/**/*.{mts,ts,tsx}`, **excluding** test files, prompts, and site/product code), the `DRAIN_EXIT_CODE = 75` contract, and the shared `shouldRestart(code)` predicate.
- **`events.mts`** — `drain-started` / `drain-complete` Live-feed events across the prose, NDJSON, and Cockpit-log renderers + the derived type-tag allow-list + emitter.
- **`cockpit-core.mts`** — `describeChildExit` classifies the drain code as `restarting` (auto-respawn), never `crashed`; `cockpit.tsx` respawns on it and keeps a crash non-respawning.
- **`main.mts`** — tracks the `origin/main` SHA the code was loaded from; after each fetch (before dispatch) detects an own-code upgrade via `git diff --name-only`, drains, and exits with `DRAIN_EXIT_CODE` once In-flight empties — emitting drain events throughout.
- **`run.mts` + `package.json`** — headless `pnpm sandcastle` runs through a small Node wrapper that relaunches only on the drain code and stops (propagating the code) on anything else.

## Acceptance criteria

- [x] Own-code commit → drain (no new dispatch, in-flight finish, distinct-code exit)
- [x] Unrelated site/product commits → no restart
- [x] Cockpit auto-respawns on the drain code + shows the drain/restart in Live; crash still does **not** respawn
- [x] Headless `pnpm sandcastle` restarts on the drain code, stops on any other exit
- [x] Drain decision logic is pure and unit-tested
- [x] `pnpm typecheck` and `pnpm test` green (552 tests)

## Verification beyond tests

- Wrapper restart mechanics driven with a fake child: restarts exactly on code 75 (×2), stops on 0, propagates the final code.
- Drain detection run against real git history: `git diff --name-only` for the #101 commit → `orchestratorCodeChanged` = true.

## Bootstrap caveat (per ADR-0013)

The detection itself lands via this phase, so **this merge still needs one manual restart** — the last one — before self-restart is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)