### PR TITLE
#124 Model profiles: defined, selected by env, headless (ADR-0016)

### DIFF
--- a/.sandcastle/events.mts
+++ b/.sandcastle/events.mts
@@ -31,6 +31,8 @@
  * `lifecycle` markers cover it), so it renders to nothing in prose mode but is
  * still emitted to the NDJSON stream so the Cockpit can show live resolutions.
  */
+import { MODEL_ROLES, type RoleModels } from "./model-profiles.mts";
+
 /** Renderer mode for the event stream. */
 export type EventFormat = "prose" | "ndjson";
 
@@ -253,6 +255,15 @@ interface DrainCompleteEvent extends BaseEvent {
   readonly commit: string;
 }
 
+/** The active Model profile was selected at startup (ADR-0016): its `profile`
+ *  name plus the resolved `models` role→model map. Emitted once, before the loop,
+ *  so the headless prose feed (and the Cockpit) shows which models are running. */
+interface ProfileSelectedEvent extends BaseEvent {
+  readonly type: "profile-selected";
+  readonly profile: string;
+  readonly models: RoleModels;
+}
+
 /**
  * The discriminated union of every orchestrator event. `type` is the single
  * discriminator the renderers switch on; the contract the Cockpit consumes.
@@ -281,7 +292,8 @@ export type OrchestratorEvent =
   | AttemptFailedEvent
   | BudgetExhaustedEvent
   | DrainStartedEvent
-  | DrainCompleteEvent;
+  | DrainCompleteEvent
+  | ProfileSelectedEvent;
 
 /** Which stdout stream a prose-rendered event belongs on (preserves the
  *  existing stdout/stderr split so headless output is unchanged). */
@@ -357,7 +369,16 @@ export function formatEventProse(event: OrchestratorEvent): string | null {
       return `  ⟳ orchestrator code changed on origin/main (${event.commit}) — draining ${event.inflight} in-flight Session(s) before restart.`;
     case "drain-complete":
       return `  ⟳ drain complete — exiting to restart on origin/main (${event.commit}).`;
+    case "profile-selected":
+      return `  ▸ Model profile "${event.profile}": ${roleModelPairs(event.models, ", ")}`;
   }
+}
+
+/** Render a role→model map as ordered `role model` pairs (MODEL_ROLES order),
+ *  joined by `sep`. Shared by the prose and Cockpit-log renderings of the
+ *  `profile-selected` event so both list the roles identically. */
+function roleModelPairs(models: RoleModels, sep: string): string {
+  return MODEL_ROLES.map((role) => `${role} ${models[role]}`).join(sep);
 }
 
 /**
@@ -488,6 +509,8 @@ export function formatEventLog(event: OrchestratorEvent): string {
       return `⟳ code changed (${event.commit}) · draining ${event.inflight} in-flight · will restart`;
     case "drain-complete":
       return `⟳ drain complete · restarting on ${event.commit}`;
+    case "profile-selected":
+      return `▸ profile ${event.profile} · ${roleModelPairs(event.models, " · ")}`;
     default: {
       // Exhaustiveness guard: adding a new OrchestratorEvent type without a log
       // line here is a compile error, so the Live log can never silently omit one.
@@ -541,6 +564,8 @@ export function eventSeverity(event: OrchestratorEvent): EventSeverity {
     case "resolver-requeued":
     case "landing-started":
     case "landing-landed":
+    // The active-profile announcement is routine startup progress (normal).
+    case "profile-selected":
       return "normal";
     default: {
       const unreachable: never = event;
@@ -581,6 +606,7 @@ const EVENT_TYPE_TAGS: Record<OrchestratorEvent["type"], true> = {
   "budget-exhausted": true,
   "drain-started": true,
   "drain-complete": true,
+  "profile-selected": true,
 };
 
 /** Every `type` discriminator the orchestrator can emit, derived from the union
@@ -695,6 +721,9 @@ export interface OrchestratorEvents {
   /** The self-restart drain finished (In-flight emptied) — exiting to restart on
    *  `commit` (ADR-0013, #102). */
   drainComplete(commit: string): void;
+  /** The active Model profile was selected at startup — its `profile` name and
+   *  resolved `models` role→model map (ADR-0016). Emitted once, before the loop. */
+  profileSelected(profile: string, models: RoleModels): void;
 }
 
 /** Options for {@link createEvents}; every dependency is injectable for tests. */
@@ -784,5 +813,7 @@ export function createEvents(opts: CreateEventsOptions = {}): OrchestratorEvents
     drainStarted: (commit, inflight) =>
       emit({ type: "drain-started", commit, inflight, ts: stamp() }),
     drainComplete: (commit) => emit({ type: "drain-complete", commit, ts: stamp() }),
+    profileSelected: (profile, models) =>
+      emit({ type: "profile-selected", profile, models, ts: stamp() }),
   };
 }

--- a/.sandcastle/events.test.mts
+++ b/.sandcastle/events.test.mts
@@ -666,6 +666,7 @@ describe("EVENT_TYPES / isKnownEventType", () => {
     "budget-exhausted",
     "drain-started",
     "drain-complete",
+    "profile-selected",
   ];
 
   it("contains exactly every orchestrator event type, no more, no fewer", () => {
@@ -736,6 +737,15 @@ describe("eventSeverity", () => {
     expect(eventSeverity(evt({ type: "review-transition", issue: 1, transition: "gate" }))).toBe(
       "normal"
     );
+    expect(
+      eventSeverity(
+        evt({
+          type: "profile-selected",
+          profile: "mixed",
+          models: { planner: "P", implementer: "I", reviewer: "R", resolver: "S" },
+        })
+      )
+    ).toBe("normal");
     expect(
       eventSeverity(
         evt({
@@ -810,5 +820,51 @@ describe("drain events", () => {
       formatEventNdjson(evt({ type: "drain-complete", commit: "abc1234" }))
     ) as Record<string, unknown>;
     expect(done).toMatchObject({ type: "drain-complete", commit: "abc1234" });
+  });
+});
+
+// ── profile-selected: the active Model profile shows in the feed (ADR-0016) ──
+
+describe("profile-selected event", () => {
+  // An explicit role→model map (independent of MODEL_PROFILES) so the renderer
+  // test pins the wording, not the profile const.
+  const models = { planner: "P", implementer: "I", reviewer: "R", resolver: "S" };
+
+  it("prose renders the name + full role→model map on stdout", () => {
+    const line = formatEventProse(evt({ type: "profile-selected", profile: "mixed", models }));
+    expect(line).toBe(
+      '  ▸ Model profile "mixed": planner P, implementer I, reviewer R, resolver S'
+    );
+    expect(eventStream(evt({ type: "profile-selected", profile: "mixed", models }))).toBe("stdout");
+  });
+
+  it("renders one compact Cockpit log line", () => {
+    expect(formatEventLog(evt({ type: "profile-selected", profile: "glm", models }))).toBe(
+      "▸ profile glm · planner P · implementer I · reviewer R · resolver S"
+    );
+  });
+
+  it("the emitter stamps and routes it once to stdout", () => {
+    const out = vi.fn();
+    const err = vi.fn();
+    const events = createEvents({
+      format: "prose",
+      now: () => new Date("2026-07-04T10:00:00.000Z"),
+      out,
+      err,
+    });
+    events.profileSelected("mixed", models);
+    expect(err).not.toHaveBeenCalled();
+    expect(out).toHaveBeenCalledTimes(1);
+    expect(out).toHaveBeenCalledWith(
+      '  ▸ Model profile "mixed": planner P, implementer I, reviewer R, resolver S'
+    );
+  });
+
+  it("ndjson carries the discriminator + name + map", () => {
+    const obj = JSON.parse(
+      formatEventNdjson(evt({ type: "profile-selected", profile: "glm", models }))
+    ) as Record<string, unknown>;
+    expect(obj).toMatchObject({ type: "profile-selected", profile: "glm", models });
   });
 });

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -48,20 +48,24 @@ import {
   type RunLike,
 } from "./observability.mts";
 import { createEvents } from "./events.mts";
+import { resolveProfile } from "./model-profiles.mts";
 
 const execFileAsync = promisify(execFile);
 
-// The merge phase (Landing) is agent-free and spends zero tokens (ADR-0012), so
-// it has no model entry — only the three agent roles do.
-const MODELS = {
-  PLANNING: "claude-opus-4-8",
-  IMPLEMENTATION: "litellm/glm-5.1",
-  REVIEW: "claude-opus-4-8",
-  // The Conflict resolver integrates a reviewed branch with origin/main — a
-  // careful, high-stakes merge (ADR-0012), so it runs on the same Opus model as
-  // review rather than the cheaper implementation model.
-  RESOLUTION: "claude-opus-4-8",
-};
+// Resolve the active Model profile from SANDCASTLE_PROFILE — never argv (ADR-0016).
+// This is the single source of the four model-bearing roles' models, replacing the
+// old hardcoded MODELS const. Unset falls back silently to `mixed` (the documented
+// default); an unknown name is a LOUD non-zero exit here, before the loop starts,
+// printing the valid names — a typo must not quietly run the wrong (expensive)
+// models. Env is the transport (not an argv flag) so the profile survives a
+// self-restart respawn (ADR-0013) for free via env inheritance; the `--profile`
+// flag on `pnpm sandcastle` is translated into this env var by run.mts.
+const profileResolution = resolveProfile(process.env.SANDCASTLE_PROFILE);
+if (!profileResolution.ok) {
+  console.error(profileResolution.error);
+  process.exit(1);
+}
+const activeProfile = profileResolution.profile;
 
 // Sandbox factory — use this everywhere instead of calling docker() directly.
 //
@@ -325,6 +329,12 @@ const ghRunner = { run: async (args: string[]) => void (await gh(args)) };
  *  the ad-hoc `console.log`s that used to be scattered through this file. */
 const events = createEvents();
 
+// Announce the active Model profile once at startup (ADR-0016), so the headless
+// prose feed (and the Cockpit) shows which models each role is running before the
+// first Poll tick. The name + resolved role→model map are the durable record of
+// what this process was launched on.
+events.profileSelected(activeProfile.name, activeProfile.models);
+
 // ── The persistent shared-pool orchestrator (ADR-0006) ──────────────────────
 //
 // One shared concurrency Pool of POOL_SIZE consumed by the two agent roles
@@ -443,7 +453,7 @@ async function dispatchImplementer(issue: {
       run: () =>
         sandbox.run({
           name: "Implementer #" + issue.number,
-          agent: sandcastle.pi(MODELS.IMPLEMENTATION, piSessions),
+          agent: sandcastle.pi(activeProfile.models.implementer, piSessions),
           promptFile: "./.sandcastle/implement-prompt.md",
           promptArgs: {
             ISSUE_NUMBER: String(issue.number),
@@ -546,7 +556,7 @@ async function dispatchReviewer(pr: {
       run: () =>
         sandbox.run({
           name: "Reviewer #" + pr.issue,
-          agent: sandcastle.pi(MODELS.REVIEW, piSessions),
+          agent: sandcastle.pi(activeProfile.models.reviewer, piSessions),
           promptFile: "./.sandcastle/review-prompt.md",
           // The prompt re-fetches the full issue via `gh issue view`, so the
           // title is just a header; it is not in the PR-bucket query, so a
@@ -803,7 +813,7 @@ async function dispatchResolver(pr: {
       run: () =>
         sandbox.run({
           name: "Conflict resolver #" + pr.issue,
-          agent: sandcastle.pi(MODELS.RESOLUTION, piSessions),
+          agent: sandcastle.pi(activeProfile.models.resolver, piSessions),
           promptFile: "./.sandcastle/resolve-prompt.md",
           promptArgs: {
             ISSUE_NUMBER: String(pr.issue),
@@ -884,7 +894,7 @@ async function runPlanner(): Promise<EmittedIssue[]> {
       sandcastle.run({
         sandbox: dockerSandbox(),
         name: "Planner",
-        agent: sandcastle.pi(MODELS.PLANNING, piSessions),
+        agent: sandcastle.pi(activeProfile.models.planner, piSessions),
         promptFile: "./.sandcastle/plan-prompt.md",
         logging: observe("planner"),
       }),

--- a/.sandcastle/model-profiles.mts
+++ b/.sandcastle/model-profiles.mts
@@ -1,0 +1,128 @@
+/**
+ * Model profiles — named presets of the role→model map (CONTEXT.md: Model
+ * profile; ADR-0016). Replaces the hardcoded `MODELS` const that used to live in
+ * `main.mts`: the four model-bearing roles (Planner, Implementer, Reviewer,
+ * Conflict resolver — the agent-free Landing has none) resolve their model
+ * through the active profile instead of a scattered literal.
+ *
+ * Kept as a typed const (mirroring how `POOL_SIZE`/`ORCHESTRATOR_SPAWN` are typed
+ * consts, not JSON) so both `main.mts` and — later — the Cockpit import ONE source
+ * of truth and every role is covered at compile time. This is the concrete shape
+ * the Repo profile's "per-role models" field will deserialize into after the
+ * Teahouse extraction (ADR-0014/0016). `glm-5.1` stays declared in `models.json`
+ * but is referenced by no profile — reserved for a future one.
+ */
+
+/** The four model-bearing roles. The agent-free Landing (ADR-0012) is NOT here —
+ *  it runs no agent and spends zero tokens, so it has no model. The single role
+ *  vocabulary every profile key and the `profile-selected` renderer speak. */
+export const MODEL_ROLES = ["planner", "implementer", "reviewer", "resolver"] as const;
+
+/** One model-bearing role. */
+export type ModelRole = (typeof MODEL_ROLES)[number];
+
+/** A fully-covered role→model map: every role resolves to a model id. */
+export type RoleModels = Record<ModelRole, string>;
+
+/**
+ * The shipped Model profiles (ADR-0016). Two to start:
+ * - `glm` — all four roles on the cheap `litellm/glm-5.2`.
+ * - `mixed` — the default: Implementer on `litellm/glm-5.2`, the other three
+ *   (Planner, Reviewer, Conflict resolver — the careful, high-stakes roles) on
+ *   `claude-opus-4-8`.
+ *
+ * `satisfies` pins every profile to a complete `RoleModels` (a missing role is a
+ * compile error) while keeping the literal key type for {@link ProfileName}.
+ */
+export const MODEL_PROFILES = {
+  glm: {
+    planner: "litellm/glm-5.2",
+    implementer: "litellm/glm-5.2",
+    reviewer: "litellm/glm-5.2",
+    resolver: "litellm/glm-5.2",
+  },
+  mixed: {
+    planner: "claude-opus-4-8",
+    implementer: "litellm/glm-5.2",
+    reviewer: "claude-opus-4-8",
+    resolver: "claude-opus-4-8",
+  },
+} satisfies Record<string, RoleModels>;
+
+/** A valid profile name — a key of {@link MODEL_PROFILES}. */
+export type ProfileName = keyof typeof MODEL_PROFILES;
+
+/** The documented default, used when `SANDCASTLE_PROFILE` is unset (ADR-0016). */
+export const DEFAULT_PROFILE: ProfileName = "mixed";
+
+/** The active Model profile: its name plus the resolved role→model map. */
+export interface ModelProfile {
+  readonly name: ProfileName;
+  readonly models: RoleModels;
+}
+
+/** The outcome of resolving a profile name: the profile, or a loud error string
+ *  the shell prints before a non-zero exit (ADR-0016). */
+export type ProfileResolution =
+  | { readonly ok: true; readonly profile: ModelProfile }
+  | { readonly ok: false; readonly error: string };
+
+/** Every valid profile name, for the "unknown name" error message and future
+ *  Cockpit picker. */
+export function profileNames(): ProfileName[] {
+  return Object.keys(MODEL_PROFILES) as ProfileName[];
+}
+
+/**
+ * Resolve the active Model profile from the `SANDCASTLE_PROFILE` env value
+ * (ADR-0016). Unset (or empty/whitespace, which is effectively unset) falls back
+ * silently to the documented default {@link DEFAULT_PROFILE}. An unknown name is
+ * NOT a silent fall-through to the default — it returns `ok: false` with a message
+ * listing the valid names, so a typo cannot quietly run the wrong (expensive)
+ * models. Pure + value-injected so the selection is unit-testable without env.
+ */
+export function resolveProfile(value: string | undefined): ProfileResolution {
+  const name = value?.trim();
+  if (!name) return { ok: true, profile: profile(DEFAULT_PROFILE) };
+  if (!isProfileName(name)) {
+    return {
+      ok: false,
+      error: `Unknown SANDCASTLE_PROFILE "${name}". Valid profiles: ${profileNames().join(", ")}.`,
+    };
+  }
+  return { ok: true, profile: profile(name) };
+}
+
+/** Build the {@link ModelProfile} for a known name. */
+function profile(name: ProfileName): ModelProfile {
+  return { name, models: MODEL_PROFILES[name] };
+}
+
+/** Narrowing guard: is `name` a declared profile? */
+function isProfileName(name: string): name is ProfileName {
+  return Object.prototype.hasOwnProperty.call(MODEL_PROFILES, name);
+}
+
+/**
+ * Pull the `--profile <name>` value out of a wrapper's argv (the human-facing
+ * surface, ADR-0016). Supports both `--profile glm` and `--profile=glm`. Returns
+ * `null` when the flag is absent or has no value — the wrapper then leaves
+ * `SANDCASTLE_PROFILE` untouched so an unset flag defaults to `mixed` (and any
+ * externally-exported env value still flows through). Validation of the NAME is
+ * `main.mts`'s job via {@link resolveProfile}, not the wrapper's — the wrapper
+ * only transports.
+ */
+export function parseProfileFlag(argv: readonly string[]): string | null {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--profile") {
+      const value = argv[i + 1];
+      return value && !value.startsWith("-") ? value : null;
+    }
+    if (arg.startsWith("--profile=")) {
+      const value = arg.slice("--profile=".length);
+      return value || null;
+    }
+  }
+  return null;
+}

--- a/.sandcastle/model-profiles.test.mts
+++ b/.sandcastle/model-profiles.test.mts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MODEL_PROFILES,
+  MODEL_ROLES,
+  parseProfileFlag,
+  resolveProfile,
+} from "./model-profiles.mts";
+
+// The expected role→model maps are written as known-good literals (the source of
+// truth is ADR-0016 / the issue), NOT derived from MODEL_PROFILES itself — so the
+// assertion can actually disagree with the const.
+
+describe("MODEL_PROFILES", () => {
+  it("runs all four roles on glm-5.2 for the glm profile", () => {
+    expect(MODEL_PROFILES.glm).toEqual({
+      planner: "litellm/glm-5.2",
+      implementer: "litellm/glm-5.2",
+      reviewer: "litellm/glm-5.2",
+      resolver: "litellm/glm-5.2",
+    });
+  });
+
+  it("runs only the Implementer on glm-5.2 for the mixed profile, the rest on Opus 4.8", () => {
+    expect(MODEL_PROFILES.mixed).toEqual({
+      planner: "claude-opus-4-8",
+      implementer: "litellm/glm-5.2",
+      reviewer: "claude-opus-4-8",
+      resolver: "claude-opus-4-8",
+    });
+  });
+
+  it("covers every model-bearing role in each profile", () => {
+    for (const profile of Object.values(MODEL_PROFILES)) {
+      for (const role of MODEL_ROLES) {
+        expect(profile[role]).toBeTruthy();
+      }
+    }
+  });
+});
+
+describe("resolveProfile", () => {
+  it("defaults to mixed silently when the value is unset", () => {
+    const result = resolveProfile(undefined);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.profile.name).toBe("mixed");
+    expect(result.profile.models).toEqual(MODEL_PROFILES.mixed);
+  });
+
+  it("treats an empty/whitespace value as unset (defaults to mixed)", () => {
+    const result = resolveProfile("   ");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.profile.name).toBe("mixed");
+  });
+
+  it("resolves a known profile name to its role→model map", () => {
+    const result = resolveProfile("glm");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.profile.name).toBe("glm");
+    expect(result.profile.models).toEqual(MODEL_PROFILES.glm);
+  });
+
+  it("fails on an unknown name with a message listing the valid names", () => {
+    const result = resolveProfile("banana");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("banana");
+    expect(result.error).toContain("glm");
+    expect(result.error).toContain("mixed");
+  });
+});
+
+describe("parseProfileFlag", () => {
+  it("reads --profile <name>", () => {
+    expect(parseProfileFlag(["--profile", "glm"])).toBe("glm");
+  });
+
+  it("reads --profile=<name>", () => {
+    expect(parseProfileFlag(["--profile=mixed"])).toBe("mixed");
+  });
+
+  it("returns null when no --profile flag is present", () => {
+    expect(parseProfileFlag(["--other", "x"])).toBeNull();
+  });
+
+  it("returns null when --profile is the last arg with no value", () => {
+    expect(parseProfileFlag(["--profile"])).toBeNull();
+  });
+});

--- a/.sandcastle/run.mts
+++ b/.sandcastle/run.mts
@@ -14,10 +14,22 @@
  */
 import { spawn } from "node:child_process";
 import { DRAIN_EXIT_CODE, shouldRestart } from "./dispatch.mts";
+import { parseProfileFlag } from "./model-profiles.mts";
 
 /** Absolute path to the orchestrator entrypoint — resolved off this module's URL
  *  so the wrapper works regardless of the process's cwd. */
 const ENTRY = new URL("./main.mts", import.meta.url).pathname;
+
+// Translate the human-facing `--profile <name>` flag into the SANDCASTLE_PROFILE
+// env var on THIS process (ADR-0016). Env is the transport, never a re-passed argv
+// flag: `main.mts` only ever reads the env var, and because every spawned child —
+// including a self-restart respawn (ADR-0013) — inherits this process's env, the
+// active profile survives a drain-restart with zero extra wiring. An absent flag
+// leaves the env untouched, so `main.mts` defaults to `mixed` (and any externally
+// exported SANDCASTLE_PROFILE still flows through). The NAME is validated by
+// `main.mts`, not here — the wrapper only transports.
+const profileFlag = parseProfileFlag(process.argv.slice(2));
+if (profileFlag !== null) process.env.SANDCASTLE_PROFILE = profileFlag;
 
 /**
  * Run the orchestrator once, inheriting stdio so its headless prose feed streams

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,6 +33,14 @@ _Avoid_: dashboard, launcher, menu.
 The interactive terminal UI (Ink, run via `tsx`) for navigating recent Runs and their Sessions from the Manifest and reading their Transcripts. Mounted both standalone (`sandcastle:browse`) and as the Cockpit's Sessions tab. Local-only, read-once (manual reload), post-hoc — the audit companion to the real-time Live feed. Two-pane: a run→session tree plus a full-screen Transcript pager. Distinct from `render-transcript`, the one-shot scriptable CLI over the same core.
 _Avoid_: viewer, dashboard, monitor.
 
+**Viewport**:
+A panel's visible, height-bounded window onto a longer list, sized to the terminal by **measuring** the rendered region rather than a hand-tuned constant. Content taller than the Viewport is reached by scrolling **within** it, never by overflowing the terminal (the Cockpit owns a full-height alternate-screen canvas — ADR-0015).
+_Avoid_: pane, window, visible area.
+
+**Follow mode**:
+The Live event log's default state of sticking to the newest events (the tail). Scrolling up **pauses** Follow mode so incoming events don't yank the view down; returning to the bottom (`G`/End) re-engages it.
+_Avoid_: tail mode, auto-scroll, stick-to-bottom.
+
 **Run**:
 One issue's **full lifecycle** through the pool — its Implementer and Reviewer Sessions, its Landing, and any Conflict-resolver Sessions — identified by a `runId` derived deterministically from the issue number (mirrors the `sandcastle/issue-N` branch). Auditing everything that happened to an issue is a single `runId` lookup. The Planner is cross-issue and does **not** belong to any issue's Run; its Sessions are recorded per-invocation with no issue binding. Distinct from sandcastle's `run()` API call, which is one agent invocation. Supersedes the old "one outer loop iteration" meaning (ADR-0006).
 _Avoid_: iteration, cycle (a Poll tick is not a Run).
@@ -89,8 +97,12 @@ _Avoid_: MR, change request.
 The orchestration engine to be extracted from `.sandcastle/` into its own repo and npm package (ADR-0014): the orchestrator loop, dispatch logic, events, observability, Cockpit, Session browser, Prune, and the Canonical prompts. Consumed per-repo via manual version bumps; each consumer repo runs its own orchestrator process. Distinct from **TeahouseHQ** (the GitHub org) and from **sandcastle**, which after extraction means only the `@ai-hero/sandcastle` sandbox library underneath.
 _Avoid_: sandcastle (for the engine, post-extraction), the harness.
 
+**Model profile**:
+A named preset of the role→model map — which model each of the four model-bearing roles (Planner, Implementer, Reviewer, Conflict resolver; the agent-free Landing has none) runs on. Two ship: `glm` (all four on glm-5.2) and `mixed` (the default: Implementer on glm-5.2, the rest on Opus 4.8). Chosen with `--profile <name>` on the sandcastle/cockpit commands, transported to the orchestrator as the `SANDCASTLE_PROFILE` env var so it survives a self-restart respawn for free (ADR-0013); an unknown name is a loud startup failure. The Cockpit distinguishes the **running** profile (the live child's) from the **selected** one (`p` cycles it; applied on the next Start, never smuggled in by an auto-restart). The concrete shape the **Repo profile**'s "per-role models" field resolves to (ADR-0016).
+_Avoid_: profile (bare — collides with Repo/Host profile), model set, roster.
+
 **Repo profile**:
-The typed per-repo config file that is a consumer repo's entire behavioral surface toward Teahouse: install/build hook, verify commands, base branch, per-role models, pool size (small default, 3–4), branch prefix, and the path to the repo-owned `CODING_STANDARDS.md`. Schema-versioned — an engine reading a profile from an incompatible schema version fails loudly at startup, never reinterprets (ADR-0014).
+The typed per-repo config file that is a consumer repo's entire behavioral surface toward Teahouse: install/build hook, verify commands, base branch, per-role models (a catalog of **Model profile**s plus the default selection), pool size (small default, 3–4), branch prefix, and the path to the repo-owned `CODING_STANDARDS.md`. Schema-versioned — an engine reading a profile from an incompatible schema version fails loudly at startup, never reinterprets (ADR-0014).
 _Avoid_: repo config, settings, sandcastle.config.
 
 **Host profile**:

--- a/docs/adr/0015-cockpit-fullscreen-measured-viewports.md
+++ b/docs/adr/0015-cockpit-fullscreen-measured-viewports.md
@@ -1,0 +1,66 @@
+# Cockpit runs fullscreen (alternate screen) with measured, per-panel viewport scrolling
+
+The Cockpit rendered into the **normal** terminal buffer via Ink's default
+`render`, growing downward from wherever the cursor sat. Panels bounded their
+height with hand-tuned constants (`termRows - 10`, `termRows - 6`) and several
+did not bound at all (the Maintenance prune buckets, the Live in-flight list),
+so whenever content was taller than the terminal the **real terminal scrolled**
+and the operator lost the top of the frame. This ADR makes the Cockpit own a
+full-height canvas and clip every long panel to a measured **Viewport** that
+scrolls internally.
+
+## Decision
+
+1. **Alternate screen buffer.** On mount, in a TTY, the Cockpit enters the
+   alternate screen buffer (`ESC[?1049h`) — the blank full-height canvas that
+   `vim`/`less`/`htop` use — and restores it (`ESC[?1049l`) on exit. Restore is
+   wired to normal quit **and** to `SIGINT`/`SIGTERM`/uncaught-throw teardown, so
+   a crash never strands the operator in the alt buffer; on clean exit their
+   shell scrollback returns intact. The supervised orchestrator's stdout is
+   **piped** (parsed into the Live feed), never written to the terminal, so the
+   child does not fight the alt screen.
+
+2. **Measured height model.** The root `Box` is pinned to `stdout.rows`; each
+   scroll region is a `flexGrow` box whose real height is read with Ink's
+   `measureElement`, and its content is sliced to that height. This deletes every
+   magic constant and self-corrects on terminal resize (Ink re-renders →
+   re-measure → clamp offsets/cursor).
+
+3. **Each long panel scrolls inside its Viewport.**
+   - **Maintenance** — the 5–6 prune buckets flatten into **one** pager-scrolled
+     Viewport (↑/↓ · PgUp/PgDn · g/G), offset-only, no per-row cursor (apply is
+     all-or-nothing, so there is nothing to select).
+   - **Live event log** — keeps auto-tail but gains scrollback with **Follow
+     mode**: a paused indicator while scrolled up, live events do not yank the
+     view down, `G`/End re-engages the tail.
+   - **In-flight list** — shows every Pool slot at natural height (≤ 10); the
+     event log `flexGrow`s into the remainder, so the operator always sees
+     everything currently running.
+
+4. **Logic in the pure core.** The offset-clamp + Follow-mode transitions are one
+   pure, unit-tested reducer in `cockpit-core.mts`, shared by both live scrollers.
+   The `.tsx` shell only wires refs, `measureElement`, and the alt-screen escape
+   writes (untested, per `CODING_STANDARDS.md`).
+
+## Considered options
+
+- **Clear the main buffer once (`ESC[2J`), stay in the normal buffer.**
+  _Rejected._ Leaves the Cockpit's final frame in scrollback on quit, does not
+  restore the operator's prior terminal contents, and risks artifacts on resize.
+- **Keep the arithmetic height (`termRows - constant`), just centralized.**
+  _Rejected._ Still hand-tuned; re-breaks every time a border/header/footer
+  changes — which is exactly the bug that let the panels overflow.
+- **Truncate each panel with a "+N more" note instead of scrolling.** _Rejected._
+  Hides items the operator can never reach inside the Cockpit, contradicting the
+  goal of scrolling within the panel.
+- **Per-panel offset math inline in the components.** _Rejected._ Duplicates the
+  clamp/follow logic across two live panels and leaves it in the untested shell,
+  against the pure-core/shell seam in `CODING_STANDARDS.md`.
+
+## Consequences
+
+- Non-TTY runs (piped stdout) skip the alt screen and fall back to sane default
+  heights, so the Cockpit still degrades cleanly when not attached to a terminal.
+- The footer help line gains the per-tab scroll keys.
+- The Session browser's tree, already Viewport-scrolled via a `termRows - 6`
+  constant, migrates onto the same measured model.

--- a/docs/adr/0016-model-profiles-selected-by-env-switched-in-cockpit.md
+++ b/docs/adr/0016-model-profiles-selected-by-env-switched-in-cockpit.md
@@ -1,0 +1,83 @@
+# Model profiles: named role→model presets, selected by env, switched in the Cockpit
+
+The four model-bearing roles (Planner, Implementer, Reviewer, Conflict
+resolver — the agent-free Landing has none) previously read their models
+from a single hardcoded `MODELS` const in `main.mts`. This ADR replaces
+that with a **Model profile**: a named preset of the role→model map,
+chosen at startup and switchable live in the Cockpit. Two ship to start:
+`glm` (all four roles on `litellm/glm-5.2`) and `mixed` (the default:
+Implementer on `litellm/glm-5.2`, the other three on `claude-opus-4-8`).
+`glm-5.1` stays declared in `models.json` but unused — reserved for a
+future profile.
+
+A Model profile is the concrete shape the Repo profile's "per-role
+models" field (ADR-0014) will deserialize into after extraction; the
+Repo profile owns the _catalog_ of profiles + the default, the runtime
+picks the _active_ one. Defined as a typed `model-profiles.mts` const
+(matching how `MODELS`/`POOL_SIZE`/`ORCHESTRATOR_SPAWN` are already
+typed consts, not JSON), so both `main.mts` and the Cockpit import one
+source of truth and every role is covered at compile time.
+
+## Selection surface: `--profile` flag, `SANDCASTLE_PROFILE` transport
+
+The human types `--profile <name>` on `pnpm sandcastle` /
+`pnpm sandcastle:cockpit`; each wrapper translates it into a
+`SANDCASTLE_PROFILE` env var on the orchestrator child. `main.mts` only
+ever reads the env var — never argv.
+
+Env, not a flag threaded through argv, because the orchestrator is
+respawned by two supervisors (`run.mts` headless, `cockpit.tsx`
+supervised) on **self-restart** (ADR-0013), a respawn the user did not
+trigger. Env is inherited by the child for free, so the active profile
+survives a drain-restart with zero new wiring — `run.mts` already
+inherits parent env, and the Cockpit already spreads `...process.env`
+into its spawn. This mirrors the existing `SANDCASTLE_EVENT_FORMAT` env
+knob exactly. A flag would force both supervisors to capture and re-pass
+the profile on every respawn.
+
+## Validation: loud on unknown, silent default when unset
+
+Owned by `main.mts`, before the loop starts. Unset → silent fallback to
+`mixed` (the documented default). Unknown (`--profile banana`) → **loud
+non-zero exit** printing the valid names, never a silent fall-through to
+a default — a typo must not quietly run the wrong (expensive) models.
+This is the ADR-0014 fail-loud-at-startup posture applied to profiles.
+The Cockpit can only ever emit names from its own picker, so an invalid
+value is reachable only from a hand-typed flag.
+
+## Cockpit switching: `selected` vs `running`, apply on Start
+
+The Cockpit holds two pieces of state: **`running`** (what the live
+child was spawned with) and **`selected`** (what the next _manual_ Start
+will use). `p` cycles `selected` on the Live tab. A switch changes only
+`selected`; it takes effect on the next Stop→Start (both single
+keystrokes). The header shows `running: X`, and `selected: Y (Start to
+apply)` only when the two differ.
+
+Crucially, an **automatic** self-restart (code upgrade, ADR-0013)
+respawns with **`running`, never `selected`** — a code-freshness restart
+must not smuggle in a model switch the user selected but never Started.
+This keeps the headless and supervised restart paths identical (the
+ADR-0013 invariant): both preserve the profile the draining child had.
+
+### Rejected switch designs
+
+- **Drain-on-demand switch** (selecting a new profile drains the live
+  child and respawns it): elegant, but invents a _parent→child_ drain
+  trigger that doesn't exist — today's drain is self-detected inside the
+  child from an upstream code change. A new signalling mechanism for a
+  marginal gain over "Stop then Start."
+- **Hard kill switch** (Stop + immediate Start on the new profile):
+  abandons in-flight Sessions mid-flight — wasted tokens and orphaned
+  draft PRs the next tick re-picks up under at-least-once dispatch.
+
+## Observability
+
+- A `profile-selected` event (name + resolved role→model map) is emitted
+  once at startup, feeding both the headless prose renderer and the
+  Cockpit — one source for both surfaces.
+- The Cockpit header surfaces `running`/`selected` as above.
+- The Manifest entry gains a per-Session **resolved model** field: the
+  durable audit trail records what each issue's Session actually ran on,
+  making cost/quality attribution a `runId` lookup. The profile name is
+  reconstructable; the model is the fact that matters.


### PR DESCRIPTION
Closes #124.

Implements the **headless** slice of ADR-0016: named role→model presets, selected by env. (Cockpit `p`-cycling / `running` vs `selected` is a later issue.)

## What changed

- **`model-profiles.mts`** (new) — the typed single source of truth replacing the hardcoded `MODELS` const. Exports `MODEL_PROFILES` with the two shipped profiles, `resolveProfile()` (env → active profile), and `parseProfileFlag()` (wrapper argv → name). Every model-bearing role is covered at compile time via `satisfies Record<string, RoleModels>`.
  - `glm` — all four roles on `litellm/glm-5.2`
  - `mixed` (default) — Implementer on `litellm/glm-5.2`, Planner/Reviewer/Conflict resolver on `claude-opus-4-8`
- **`main.mts`** — resolves the active profile from `SANDCASTLE_PROFILE` (never argv) before the loop: unset → `mixed` silently; unknown → loud non-zero exit listing the valid names. The four roles now run through `activeProfile.models.*`.
- **`events.mts`** — new `profile-selected` event (name + resolved role→model map), rendered in the headless prose feed and the Cockpit log, emitted once at startup.
- **`run.mts`** — translates the human-facing `--profile <name>` flag into `SANDCASTLE_PROFILE` on its env, so a self-restart respawn (ADR-0013) preserves the active profile for free via env inheritance.
- `glm-5.1` stays declared in `models.json`, unused — reserved for a future profile.

## Acceptance criteria

- [x] `model-profiles.mts` exports typed `glm`/`mixed`; `MODELS` gone; all four roles resolve through the active profile
- [x] `--profile glm` → all four on glm-5.2; `--profile mixed`/no flag → Implementer on glm-5.2, rest on Opus 4.8
- [x] Unset defaults to `mixed` silently; unknown exits non-zero before the loop listing valid names
- [x] `profile-selected` event emitted once at startup, shown in the headless prose feed
- [x] `--profile` flag reaches the orchestrator as `SANDCASTLE_PROFILE`; respawn preserves it (env inheritance)
- [x] `glm-5.1` remains in `models.json`

## Testing

- TDD: red→green per slice. New `model-profiles.test.mts` (profiles, `resolveProfile`, `parseProfileFlag`) + `profile-selected` coverage added to `events.test.mts`.
- Full suite green (567 tests); `sandcastle:typecheck` clean.
- End-to-end verified live: unset → `mixed` line, `--profile glm` → all-glm line, `--profile banana` → loud exit(1) both via env and via the wrapper flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)