### PR TITLE
#126 Per-Session resolved model in the Manifest (ADR-0016)

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -102,6 +102,10 @@ async function recordedRun<R extends RunLike>(args: {
   phase: string;
   issue?: number | null;
   branch?: string | null;
+  /** The concrete model this Session runs on, resolved from the active Model
+   *  profile's map for the phase's role (ADR-0016). Recorded in the Manifest —
+   *  on both the ok and failed paths — so a cost/quality audit is a runId lookup. */
+  resolvedModel: string;
   run: () => Promise<R>;
   /** Extract the Session's structured Outcome from its result for the Manifest
    *  (ADR-0011). Given for the Reviewer (parses its `<outcome>` tag); omitted for
@@ -117,6 +121,7 @@ async function recordedRun<R extends RunLike>(args: {
         phase: args.phase,
         issue: args.issue,
         branch: args.branch,
+        resolvedModel: args.resolvedModel,
         result,
         startedAt,
         endedAt: new Date(),
@@ -135,6 +140,7 @@ async function recordedRun<R extends RunLike>(args: {
         phase: args.phase,
         issue: args.issue,
         branch: args.branch,
+        resolvedModel: args.resolvedModel,
         error,
         session,
         startedAt,
@@ -450,6 +456,7 @@ async function dispatchImplementer(issue: {
       phase: "impl",
       issue: issue.number,
       branch: issue.branch,
+      resolvedModel: activeProfile.models.implementer,
       run: () =>
         sandbox.run({
           name: "Implementer #" + issue.number,
@@ -551,6 +558,7 @@ async function dispatchReviewer(pr: {
       phase: "rev",
       issue: pr.issue,
       branch: pr.branch,
+      resolvedModel: activeProfile.models.reviewer,
       // ADR-0011: record the Reviewer's parsed Outcome in the Manifest entry.
       outcome: (r) => parseOutcome(r.stdout),
       run: () =>
@@ -808,6 +816,7 @@ async function dispatchResolver(pr: {
       phase: "resolve",
       issue: pr.issue,
       branch: pr.branch,
+      resolvedModel: activeProfile.models.resolver,
       // ADR-0011: record the resolver's parsed Outcome in the Manifest entry.
       outcome: (r) => parseOutcome(r.stdout),
       run: () =>
@@ -890,6 +899,7 @@ async function runPlanner(): Promise<EmittedIssue[]> {
   const plan = await recordedRun({
     runId: plannerRunId,
     phase: "planner",
+    resolvedModel: activeProfile.models.planner,
     run: () =>
       sandcastle.run({
         sandbox: dockerSandbox(),

--- a/.sandcastle/observability.mts
+++ b/.sandcastle/observability.mts
@@ -309,6 +309,12 @@ export interface ManifestEntry {
    *  parseable Outcome (a failed attempt against the Retry budget). Lets the
    *  Session browser show pass/give-up/no-outcome at a glance. */
   readonly outcome: ParsedOutcome | null;
+  /** The concrete model this Session actually ran on (e.g. `litellm/glm-5.2`,
+   *  `claude-opus-4-8`), resolved at dispatch from the active Model profile's map
+   *  for the phase's role (ADR-0016). Null for an agent-free Landing (ADR-0012),
+   *  which runs no agent and has no model. The profile name is reconstructable;
+   *  the resolved model is the fact worth persisting for cost/quality audits. */
+  readonly resolvedModel: string | null;
   /** Present only on failed entries: the error message. */
   readonly error?: string;
 }
@@ -321,6 +327,9 @@ interface ManifestEntryArgs {
   readonly branch?: string | null;
   readonly startedAt: Date;
   readonly endedAt: Date;
+  /** The concrete model resolved for this Session's role at dispatch (ADR-0016),
+   *  or null/omitted for an agent-free Landing that ran no agent (ADR-0012). */
+  readonly resolvedModel?: string | null;
 }
 
 /**
@@ -344,6 +353,7 @@ export function buildManifestEntry(
     endedAt: args.endedAt.toISOString(),
     status: "ok",
     outcome: args.outcome ?? null,
+    resolvedModel: args.resolvedModel ?? null,
   };
 }
 
@@ -384,6 +394,7 @@ export function buildFailedManifestEntry(
     endedAt: args.endedAt.toISOString(),
     status: "failed",
     outcome: null,
+    resolvedModel: args.resolvedModel ?? null,
     error: errorMessage(args.error),
   };
 }

--- a/.sandcastle/observability.test.mts
+++ b/.sandcastle/observability.test.mts
@@ -354,7 +354,25 @@ describe("buildManifestEntry", () => {
       endedAt: "2026-06-28T12:05:00.000Z",
       status: "ok",
       outcome: null,
+      resolvedModel: null,
     });
+  });
+
+  it("records the concrete resolved model the agent Session ran on (#126)", () => {
+    // At dispatch the orchestrator passes the active profile's model for this
+    // role; the durable audit trail records what the Session actually ran on so
+    // a cost/quality attribution is a runId lookup (ADR-0016).
+    const entry = buildManifestEntry({
+      runId: "run-issue-126",
+      phase: "impl",
+      issue: 126,
+      branch: "sandcastle/issue-126",
+      result: okResult(),
+      startedAt: new Date(0),
+      endedAt: new Date(0),
+      resolvedModel: "litellm/glm-5.2",
+    });
+    expect(entry.resolvedModel).toBe("litellm/glm-5.2");
   });
 
   it("records the parsed Outcome when one is supplied (ADR-0011)", () => {
@@ -391,6 +409,8 @@ describe("buildManifestEntry", () => {
     expect(entry.commits).toBe(0);
     expect(entry.outcome).toBeNull();
     expect(entry.status).toBe("ok");
+    // Agent-free: no agent ran, so no model was resolved for it (#126, ADR-0016).
+    expect(entry.resolvedModel).toBeNull();
   });
 
   it("defaults the Outcome to null for phases that report none (impl/planner/land)", () => {
@@ -451,6 +471,7 @@ describe("buildFailedManifestEntry", () => {
       status: "failed",
       error: "boom",
       outcome: null,
+      resolvedModel: null,
     });
   });
 


### PR DESCRIPTION
Closes #126.

## What

Records, per Session, the concrete model it actually ran on, so a cost/quality audit is a `runId` lookup. Populated at dispatch from the active Model profile's mapping for that role (ADR-0016).

- `ManifestEntry` gains a `resolvedModel: string | null` field, threaded through `buildManifestEntry` (and `buildFailedManifestEntry`) via the shared `ManifestEntryArgs`.
- `recordedRun` in `main.mts` takes the resolved model and passes it on both the ok and failed paths; each of the four agent call sites supplies `activeProfile.models.<role>` (Planner, Implementer, Reviewer, Conflict resolver).
- The agent-free **Landing** builds its entry directly and omits the field, so it carries `null` — no agent ran, no model.

## Acceptance criteria

- [x] `ManifestEntry` gains a resolved-model field, threaded through `buildManifestEntry`
- [x] Each agent Session's Manifest line records the concrete model it ran on (e.g. `litellm/glm-5.2`, `claude-opus-4-8`)
- [x] A Landing's Manifest entry carries no resolved model (agent-free)
- [x] `observability.mts` tests cover the new field for both a populated agent Session and an agent-free Landing

## Testing

- `observability.test.mts`: new assertions for a populated agent Session (records the concrete model) and the agent-free Landing (null); existing full-shape tests updated for the new field.
- Full suite green (573 tests); `tsc --noEmit` clean — the now-required `resolvedModel` on `recordedRun` forces every agent call site to supply its role's model at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)